### PR TITLE
ci(security): add explicit permissions to all workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
     name: Code linting
     runs-on: ubuntu-latest
     needs: [deps]
+    permissions:
+      contents: read
     strategy:
       matrix:
         command:
@@ -78,6 +80,7 @@ jobs:
     name: Code linting Report
     runs-on: ubuntu-latest
     needs: [lint]
+    permissions: {}
     if: ${{ always() }}
     steps:
       - name: Linting fail
@@ -88,6 +91,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: [deps]
+    permissions:
+      contents: read
     strategy:
       matrix:
         shardIndex: [1, 2, 3]
@@ -121,6 +126,8 @@ jobs:
     name: Merge Coverage Reports
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -150,6 +157,7 @@ jobs:
     name: Unit Tests Report
     runs-on: ubuntu-latest
     needs: [test, coverage]
+    permissions: {}
     if: ${{ always() }}
     steps:
       - name: Unit tests fail


### PR DESCRIPTION
Add explicit permissions to all jobs in the release workflow that were missing them.

**Severity:** Medium
**Rule:** actions/missing-workflow-permissions

**Alerts resolved:**
- [#3](https://github.com/cosmocoder/CodeCritique/security/code-scanning/3) — .github/workflows/release.yml:52 (lint)
- [#4](https://github.com/cosmocoder/CodeCritique/security/code-scanning/4) — .github/workflows/release.yml:78 (lint-report)
- [#5](https://github.com/cosmocoder/CodeCritique/security/code-scanning/5) — .github/workflows/release.yml:88 (test)
- [#6](https://github.com/cosmocoder/CodeCritique/security/code-scanning/6) — .github/workflows/release.yml:121 (coverage)
- [#8](https://github.com/cosmocoder/CodeCritique/security/code-scanning/8) — .github/workflows/release.yml:150 (test-report)

**Changes:**
Added least-privilege permissions to five workflow jobs: `contents: read` for jobs that need checkout and cache access (lint, test, coverage), and empty permissions (`permissions: {}`) for report jobs that need no repository access (lint-report, test-report).