### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,6 @@
 name: Dependabot auto-merge
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write


### PR DESCRIPTION
Dependabot-triggered `pull_request` events don't have access to repository secrets, causing the `create-github-app-token` step to fail with `appId option is required`. 

We switch to `pull_request_target` so the workflow runs in the base branch context where secrets are available. This is safe because the workflow only approves/merges via GitHub API and never checks out PR code.