### PR TITLE
Limit Dependabot updates and label security PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 20
     versioning-strategy: 'increase'
+    allow:
+      - dependency-type: 'direct'
     labels:
       - 'dependencies'
     commit-message:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,17 +13,36 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
+      # Generated unconditionally so the security-advisory lookup below can use it.
       - name: Generate GitHub App token
         id: app-token
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # Resolve the GHSA advisory behind security updates so they can be labelled.
+      # alert-lookup requires the App to have "Dependabot alerts: Read"; the default
+      # GITHUB_TOKEN cannot read alerts. continue-on-error keeps auto-merge working
+      # even if that permission is missing (ghsa-id is simply empty -> no label).
+      - name: Look up security advisory
+        id: security
+        continue-on-error: true
+        uses: dependabot/fetch-metadata@v3
+        with:
+          alert-lookup: true
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: Label security updates
+        if: steps.security.outputs.ghsa-id != ''
+        run: gh pr edit "$PR_URL" --add-label security
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve the PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'


### PR DESCRIPTION
## Problem

Dependabot can open routine npm PRs for transitive dependency changes, and semantic-release can turn those lockfile-only updates into releases even when they have no published consumer impact. Security-driven transitive updates can still be created, but they were not clearly marked as security-related.

## Fix

Restrict npm Dependabot version updates to direct dependencies, while adding a security-advisory lookup to the Dependabot workflow. When `dependabot/fetch-metadata` finds a GHSA advisory, the workflow applies the existing `security` label and leaves the patch/minor auto-approval behavior unchanged.

## Validation

- `./node_modules/.bin/prettier --check .github/dependabot.yml .github/workflows/dependabot.yml`