### PR TITLE
chore(actions): harden GitHub Actions input handling

### DIFF
--- a/.github/actions/cleanup-artifacts/action.yml
+++ b/.github/actions/cleanup-artifacts/action.yml
@@ -143,7 +143,6 @@ runs:
       working-directory: ${{ github.action_path }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        GITHUB_OUTPUT: ${{ github.output }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         INPUT_CLEANUP_TYPE: ${{ inputs.cleanup-type }}
         INPUT_OLDER_THAN_DAYS: ${{ inputs.older-than-days }}

--- a/.github/actions/cleanup-artifacts/cleanup-artifacts.js
+++ b/.github/actions/cleanup-artifacts/cleanup-artifacts.js
@@ -226,13 +226,38 @@ const defaultGithubToken = process.env.GITHUB_TOKEN;
 const defaultOutputFile = process.env.GITHUB_OUTPUT;
 
 /**
+ * Format an output assignment for GitHub Actions' $GITHUB_OUTPUT file.
+ * @param {string} name - Output name
+ * @param {string|number|boolean|null|undefined} value - Output value
+ * @returns {string} Formatted output entry
+ */
+export function formatGithubOutput(name, value) {
+  if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(name)) {
+    throw new Error(`Invalid GitHub Actions output name: ${name}`);
+  }
+
+  const outputValue = value == null ? '' : String(value);
+  if (!/[\r\n]/.test(outputValue)) {
+    return `${name}=${outputValue}\n`;
+  }
+
+  let delimiter = `ghadelimiter_${name.replace(/[^A-Za-z0-9_]/g, '_')}`;
+  let suffix = 0;
+  while (outputValue.includes(delimiter)) {
+    suffix += 1;
+    delimiter = `ghadelimiter_${name.replace(/[^A-Za-z0-9_]/g, '_')}_${suffix}`;
+  }
+
+  return `${name}<<${delimiter}\n${outputValue}\n${delimiter}\n`;
+}
+
+/**
  * Append output to GitHub Actions output file
  */
 export function setOutput(name, value, outputFilePath = defaultOutputFile) {
   if (outputFilePath) {
-    fs.appendFileSync(outputFilePath, `${name}=${value}\n`);
+    fs.appendFileSync(outputFilePath, formatGithubOutput(name, value));
   }
-  console.log(`::set-output name=${name}::${value}`);
 }
 
 /**

--- a/.github/actions/cleanup-artifacts/cleanup-artifacts.test.js
+++ b/.github/actions/cleanup-artifacts/cleanup-artifacts.test.js
@@ -9,6 +9,7 @@ import {
   generateSummary,
   createCleanupReport,
   bytesToMb,
+  formatGithubOutput,
   setOutput,
   setOutputs,
   fetchArtifacts,
@@ -418,19 +419,43 @@ describe('cleanup-artifacts.js', () => {
       const outputFile = '/tmp/test-output';
       setOutput('test-key', 'test-value', outputFile);
       expect(fs.appendFileSync).toHaveBeenCalledWith(outputFile, 'test-key=test-value\n');
-      expect(console.log).toHaveBeenCalledWith('::set-output name=test-key::test-value');
     });
 
     it('should not write to file when output file is not provided', () => {
       setOutput('test-key', 'test-value', null);
       expect(fs.appendFileSync).not.toHaveBeenCalled();
-      expect(console.log).toHaveBeenCalledWith('::set-output name=test-key::test-value');
     });
 
     it('should handle empty values', () => {
       const outputFile = '/tmp/test-output';
       setOutput('empty-key', '', outputFile);
       expect(fs.appendFileSync).toHaveBeenCalledWith(outputFile, 'empty-key=\n');
+    });
+
+    it('should handle multiline values safely', () => {
+      const outputFile = '/tmp/test-output';
+      setOutput('summary', 'Deleted artifact\nSkipped artifact', outputFile);
+
+      expect(fs.appendFileSync).toHaveBeenCalledWith(
+        outputFile,
+        'summary<<ghadelimiter_summary\nDeleted artifact\nSkipped artifact\nghadelimiter_summary\n'
+      );
+    });
+  });
+
+  describe('formatGithubOutput', () => {
+    it('should format single-line output values', () => {
+      expect(formatGithubOutput('report-path', 'cleanup-report.json')).toBe('report-path=cleanup-report.json\n');
+    });
+
+    it('should choose a delimiter that does not appear in the output value', () => {
+      expect(formatGithubOutput('summary', 'line 1\nghadelimiter_summary\nline 3')).toBe(
+        'summary<<ghadelimiter_summary_1\nline 1\nghadelimiter_summary\nline 3\nghadelimiter_summary_1\n'
+      );
+    });
+
+    it('should reject invalid output names', () => {
+      expect(() => formatGithubOutput('bad\nname', 'value')).toThrow('Invalid GitHub Actions output name');
     });
   });
 

--- a/.github/actions/generate-embeddings/action.yml
+++ b/.github/actions/generate-embeddings/action.yml
@@ -88,6 +88,8 @@ runs:
         DEBUG: ${{ inputs.verbose }}
         VERBOSE: ${{ inputs.verbose }}
         GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
       run: |
         echo "🧠 Generating embeddings for codebase..."
 
@@ -100,8 +102,9 @@ runs:
         fi
 
         # Add specific files if provided
-        if [ -n "${{ inputs.files }}" ]; then
-          for file_pattern in ${{ inputs.files }}; do
+        if [ -n "$INPUT_FILES" ]; then
+          read -r -a FILE_PATTERNS <<< "$INPUT_FILES"
+          for file_pattern in "${FILE_PATTERNS[@]}"; do
             ARGS+=("--files" "${file_pattern}")
           done
         fi
@@ -111,8 +114,9 @@ runs:
         ARGS+=("--exclude" ".codecritique-artifacts/**")
 
         # Add user-specified exclude patterns
-        if [ -n "${{ inputs.exclude }}" ]; then
-          for pattern in ${{ inputs.exclude }}; do
+        if [ -n "$INPUT_EXCLUDE" ]; then
+          read -r -a EXCLUDE_PATTERNS <<< "$INPUT_EXCLUDE"
+          for pattern in "${EXCLUDE_PATTERNS[@]}"; do
             ARGS+=("--exclude" "${pattern}")
           done
         fi


### PR DESCRIPTION
## Problem

Some GitHub Actions output and shell handling paths were unnecessarily brittle for CI workflows:

- The cleanup action still emitted deprecated `::set-output` commands and wrote raw `name=value` entries to `$GITHUB_OUTPUT`, which is unsafe for multiline output values.
- The cleanup action overrode `GITHUB_OUTPUT` with a nonstandard context, bypassing the runner-provided output file path.
- The generate-embeddings action expanded `files` and `exclude` inputs directly inside shell `for` loops, allowing shell re-parsing of user-provided patterns.

## Fix

Harden the CI action handling without changing consumer-facing action inputs:

- Format cleanup action outputs using the multiline-safe `$GITHUB_OUTPUT` syntax.
- Remove the deprecated `::set-output` fallback.
- Preserve the native runner-provided `GITHUB_OUTPUT` path.
- Route only the shell-looped `files` and `exclude` inputs through environment variables before parsing them into quoted bash arrays.
