### PR TITLE
Scope cleanup queries by project

### DIFF
--- a/src/embeddings/database.js
+++ b/src/embeddings/database.js
@@ -823,9 +823,9 @@ export class DatabaseManager {
    */
   async _clearProjectTableRecords(db, tableName, resolvedProjectPath, pathField) {
     const table = await db.openTable(tableName);
-    const allRecords = await table.query().toArray();
+    const records = await this._getProjectTableRecords(table, tableName, resolvedProjectPath, pathField);
 
-    const projectRecords = allRecords.filter((record) => {
+    const projectRecords = records.filter((record) => {
       if (!record[pathField]) {
         return false;
       }
@@ -866,6 +866,34 @@ export class DatabaseManager {
       verboseLog({}, chalk.yellow(`No ${tableName} records found for this project`));
       return 0;
     }
+  }
+
+  /**
+   * Fetch candidate cleanup records, using a project-scoped table query when the schema supports it.
+   * @param {LanceDBTable} table - Table instance
+   * @param {string} tableName - Table name
+   * @param {string} resolvedProjectPath - Resolved project path
+   * @param {string} pathField - Field used to scope project records
+   * @returns {Promise<Object[]>} Candidate cleanup records
+   * @private
+   */
+  async _getProjectTableRecords(table, tableName, resolvedProjectPath, pathField) {
+    try {
+      const currentSchema = await getTableSchema(table);
+
+      if (pathField === 'project_path' && schemaHasField(currentSchema, 'project_path')) {
+        return await table
+          .query()
+          .where(`project_path = '${escapeSqlString(resolvedProjectPath)}'`)
+          .toArray();
+      }
+    }
+    catch (queryError) {
+      debug(`Could not query ${tableName} by ${pathField}: ${queryError.message}`);
+    }
+
+    verboseLog({}, chalk.yellow(`Falling back to full ${tableName} scan for project cleanup`));
+    return await table.query().toArray();
   }
 
   /**

--- a/src/embeddings/database.test.js
+++ b/src/embeddings/database.test.js
@@ -328,6 +328,20 @@ describe('DatabaseManager', () => {
       expect(mockTable.delete).toHaveBeenCalled();
     });
 
+    it('should query project-scoped records when project_path is available', async () => {
+      const queryChain = {
+        where: vi.fn().mockReturnThis(),
+        toArray: vi.fn().mockResolvedValue([{ id: "record'1", project_path: "/test/it's/project/deep" }]),
+      };
+      mockDb.tableNames.mockResolvedValue(['file_embeddings']);
+      mockTable.query.mockReturnValue(queryChain);
+
+      await dbManager.clearProjectEmbeddings("/test/it's/project/deep");
+
+      expect(queryChain.where).toHaveBeenCalledWith("project_path = '/test/it''s/project/deep'");
+      expect(mockTable.delete).toHaveBeenCalledWith("id = 'record''1'");
+    });
+
     it('should handle non-existent database', async () => {
       fs.existsSync.mockReturnValue(false);
       expect(await dbManager.clearProjectEmbeddings('/test/project/deep')).toBe(true);

--- a/src/project-analyzer.js
+++ b/src/project-analyzer.js
@@ -14,6 +14,7 @@ import * as llm from './llm.js';
 import { FILE_SELECTION_SYSTEM_PROMPT, PROJECT_SUMMARY_SYSTEM_PROMPT } from './prompt-cache.js';
 import { isDocumentationFile, isTestFile } from './utils/file-validation.js';
 import { verboseLog } from './utils/logging.js';
+import { escapeSqlString } from './utils/string-utils.js';
 
 // Consolidated file classification configuration
 const FILE_PATTERNS = {
@@ -377,6 +378,7 @@ export class ProjectAnalyzer {
 
     try {
       verboseLog({}, chalk.gray(`   📊 Using LanceDB hybrid search for project: ${projectPath}`));
+      const projectPathFilter = `project_path = '${escapeSqlString(projectPath)}'`;
 
       // Unified query function
       const queryFiles = async (config) => {
@@ -384,15 +386,11 @@ export class ProjectAnalyzer {
           let query = table.query().select(['path', 'name', 'content', 'type', 'language']);
 
           if (config.whereClause) {
-            query = query.where(`project_path = '${projectPath}' AND (${config.whereClause})`);
+            query = query.where(`${projectPathFilter} AND (${config.whereClause})`);
           }
           else if (config.terms) {
             // For term-based searches, query ALL files and sort by depth to prioritize shallow config files
-            const allFiles = await table
-              .query()
-              .select(['path', 'name', 'content', 'type', 'language'])
-              .where(`project_path = '${projectPath}'`)
-              .toArray(); // NO LIMIT - get all files
+            const allFiles = await table.query().select(['path', 'name', 'content', 'type', 'language']).where(projectPathFilter).toArray(); // NO LIMIT - get all files
 
             // Sort by path depth (shorter paths first) to prioritize config files
             allFiles.sort((a, b) => {
@@ -416,7 +414,7 @@ export class ProjectAnalyzer {
             });
           }
           else {
-            query = query.where(`project_path = '${projectPath}'`);
+            query = query.where(projectPathFilter);
           }
 
           return await query.limit(config.limit || 30).toArray();
@@ -655,7 +653,7 @@ Select files following the criteria in the system instructions.`;
       const records = await table
         .query()
         .select(['type', 'path', 'content_hash', 'project_path'])
-        .where(`project_path = '${projectPath.replace(/'/g, "''")}'`)
+        .where(`project_path = '${escapeSqlString(projectPath)}'`)
         .toArray();
 
       const hash = crypto.createHash('sha256');

--- a/src/project-analyzer.test.js
+++ b/src/project-analyzer.test.js
@@ -402,6 +402,14 @@ describe('ProjectAnalyzer', () => {
       expect(mockTable.query).toHaveBeenCalled();
     });
 
+    it('should escape project paths in key file queries', async () => {
+      const queryChain = mockTable.query();
+
+      await analyzer.mineKeyFilesFromEmbeddings("/mock/we're/project");
+
+      expect(queryChain.where).toHaveBeenCalledWith(expect.stringContaining("/mock/we''re/project"));
+    });
+
     it('should handle table optimization errors gracefully', async () => {
       mockTable.optimize.mockRejectedValue(new Error('legacy format'));
       mockTable.query().toArray.mockResolvedValue([]);


### PR DESCRIPTION
## Problem

- `embeddings:clear` scanned entire tables and filtered records in JavaScript, which is inefficient for large multi-project LanceDB stores.
- Project analyzer LanceDB filters interpolated `projectPath` directly in a few queries, so paths containing apostrophes could break project analysis filters.

## Fix

Use project-scoped LanceDB filtering where modern schemas support `project_path`, while retaining the legacy full-table fallback for older or unreadable schemas. Also route project analyzer filters through the existing `escapeSqlString()` utility so project paths are escaped consistently.