### PR TITLE
Fix RAG context sync edge cases

### DIFF
--- a/src/embeddings/database.js
+++ b/src/embeddings/database.js
@@ -232,6 +232,7 @@ export class DatabaseManager {
       }
       else {
         prCommentsTable = await db.openTable(this.prCommentsTable);
+        await this._ensureSchemaField(prCommentsTable, this.prCommentsTable, new Field('pr_updated_at', new Utf8(), true));
       }
 
       // Create FTS indexes
@@ -354,6 +355,7 @@ export class DatabaseManager {
       new Field('author', new Utf8(), false),
       new Field('created_at', new Utf8(), false),
       new Field('updated_at', new Utf8(), true),
+      new Field('pr_updated_at', new Utf8(), true),
       new Field('review_id', new Utf8(), true),
       new Field('review_state', new Utf8(), true),
 
@@ -705,6 +707,28 @@ export class DatabaseManager {
     }
     catch (schemaError) {
       debug(`Could not check schema for ${tableName}: ${schemaError.message}`);
+    }
+  }
+
+  /**
+   * Add a nullable field to an existing LanceDB table when it is missing.
+   * @param {LanceDBTable} table - Table instance
+   * @param {string} tableName - Table name
+   * @param {Field} field - Field to add
+   * @private
+   */
+  async _ensureSchemaField(table, tableName, field) {
+    try {
+      const currentSchema = await getTableSchema(table);
+      if (!currentSchema?.fields || schemaHasField(currentSchema, field.name)) {
+        return;
+      }
+
+      verboseLog({}, chalk.yellow(`Adding missing ${field.name} column to ${tableName} table...`));
+      await table.addColumns(field);
+    }
+    catch (schemaError) {
+      console.warn(chalk.yellow(`Warning: Could not add ${field.name} column to ${tableName}: ${schemaError.message}`));
     }
   }
 

--- a/src/embeddings/database.test.js
+++ b/src/embeddings/database.test.js
@@ -31,6 +31,7 @@ const createMockTable = (overrides = {}) => ({
   schema: { fields: [{ name: 'project_path' }] },
   query: vi.fn().mockReturnValue({ where: vi.fn().mockReturnThis(), toArray: vi.fn().mockResolvedValue([]) }),
   add: vi.fn().mockResolvedValue(undefined),
+  addColumns: vi.fn().mockResolvedValue(undefined),
   delete: vi.fn().mockResolvedValue(undefined),
   optimize: vi.fn().mockResolvedValue(undefined),
   ...overrides,

--- a/src/embeddings/factory.js
+++ b/src/embeddings/factory.js
@@ -339,7 +339,7 @@ class EmbeddingsSystem {
    * @returns {Promise<import('@lancedb/lancedb').Table|null>} PR comments table or null on error
    */
   async getPRCommentsTable() {
-    await this.databaseManager.getDBConnection();
+    await this.databaseManager.initializeTables();
     return this.databaseManager.getTable(this.databaseManager.prCommentsTable);
   }
 

--- a/src/embeddings/factory.test.js
+++ b/src/embeddings/factory.test.js
@@ -246,10 +246,10 @@ describe('EmbeddingsSystem', () => {
   });
 
   describe('getPRCommentsTable', () => {
-    it('should get PR comments table without initializing models', async () => {
+    it('should initialize PR comments schema without initializing models', async () => {
       await system.getPRCommentsTable();
 
-      expect(system.databaseManager.getDBConnection).toHaveBeenCalled();
+      expect(system.databaseManager.initializeTables).toHaveBeenCalled();
       expect(system.databaseManager.getTable).toHaveBeenCalledWith('pr_comments');
       expect(system.modelManager.initialize).not.toHaveBeenCalled();
     });

--- a/src/embeddings/file-processor.js
+++ b/src/embeddings/file-processor.js
@@ -555,7 +555,7 @@ export class FileProcessor {
           }
 
           candidate.embeddingContent = embeddingContent;
-          candidate.contentHash = createShortHash(embeddingContent);
+          candidate.contentHash = createShortHash(rawContent);
           sharedState.liveFilePaths.add(candidate.relativePath);
 
           const unchangedRecord = candidate.existingRecords.find((record) => record.content_hash === candidate.contentHash);

--- a/src/embeddings/file-processor.test.js
+++ b/src/embeddings/file-processor.test.js
@@ -12,8 +12,31 @@ vi.mock('node:fs', () => ({
   },
 }));
 
+const mockCreateHash = vi.hoisted(() =>
+  vi.fn(() => {
+    let content = '';
+    const hash = {
+      update: vi.fn((value) => {
+        content += String(value);
+        return hash;
+      }),
+      digest: vi.fn(() => {
+        if (content === 'const x = 1;') {
+          return 'abc12345';
+        }
+        let total = 0;
+        for (let i = 0; i < content.length; i += 1) {
+          total = (total + content.charCodeAt(i) * (i + 1)) % 0xffffffff;
+        }
+        return total.toString(16).padStart(8, '0');
+      }),
+    };
+    return hash;
+  })
+);
+
 vi.mock('node:crypto', () => ({
-  createHash: vi.fn(() => ({ update: vi.fn().mockReturnThis(), digest: vi.fn().mockReturnValue('abc12345') })),
+  createHash: mockCreateHash,
 }));
 
 vi.mock('../utils/file-validation.js', () => ({
@@ -47,6 +70,17 @@ const createDirEntry = (name, isDir = false) => ({
   isDirectory: () => isDir,
   isFile: () => !isDir,
 });
+
+const mockHashFor = (content) => {
+  if (content === 'const x = 1;') {
+    return 'abc12345';
+  }
+  let total = 0;
+  for (let i = 0; i < content.length; i += 1) {
+    total = (total + content.charCodeAt(i) * (i + 1)) % 0xffffffff;
+  }
+  return total.toString(16).padStart(8, '0').slice(0, 8);
+};
 
 // ============================================================================
 // Tests
@@ -388,6 +422,23 @@ describe('FileProcessor', () => {
       const result = await processor.processBatchEmbeddings(['/test/file.js'], { baseDir: '/test' });
       expect(result.skipped).toBeGreaterThan(0);
       expect(mockModelManager.calculateEmbeddingBatch).not.toHaveBeenCalled();
+    });
+
+    it('should process long files when content changes beyond the embedding truncation window', async () => {
+      const unchangedPrefix = Array.from({ length: 1000 }, (_, i) => `const x${i} = ${i};`).join('\n');
+      const changedRawContent = `${unchangedPrefix}\nconst changedTail = true;`;
+      const oldTruncatedContent = `${unchangedPrefix}\n... (truncated from 1001 lines)`;
+
+      setupFileSystemMocks(changedRawContent);
+      mockTable.query.mockReturnValue({
+        where: vi.fn().mockReturnThis(),
+        toArray: vi.fn().mockResolvedValue([{ id: 'old-record', path: 'file.js', content_hash: mockHashFor(oldTruncatedContent) }]),
+      });
+
+      const result = await processor.processBatchEmbeddings(['/test/file.js'], { baseDir: '/test', maxLines: 1000 });
+
+      expect(result.processed).toBeGreaterThan(0);
+      expect(mockModelManager.calculateEmbeddingBatch).toHaveBeenCalled();
     });
 
     it('should delete old version when content hash differs', async () => {

--- a/src/pr-history/analyzer.js
+++ b/src/pr-history/analyzer.js
@@ -8,7 +8,7 @@
 import chalk from 'chalk';
 import { verboseLog } from '../utils/logging.js';
 import { PRCommentProcessor } from './comment-processor.js';
-import { clearPRComments, getPRCommentsStats, getProcessedPRDateRange, shouldSkipPR, storePRCommentsBatch } from './database.js';
+import { clearPRComments, getPRCommentsStats, getProcessedPRSyncState, shouldSkipPR, storePRCommentsBatch } from './database.js';
 import { GitHubAPIClient } from './github-client.js';
 
 /**
@@ -187,12 +187,12 @@ export class PRHistoryAnalyzer {
       this.progress.updatePRs(prs.length, 0);
 
       // Step 2: Process PR comments
-      const processedComments = await this.processPRComments(prs, { onProgress, projectPath, verbose });
+      const { comments: processedComments, processedPRs } = await this.processPRComments(prs, { onProgress, projectPath, verbose });
 
       // Step 3: Store in database
-      if (processedComments.length > 0) {
+      if (processedComments.length > 0 || processedPRs.length > 0) {
         verboseLog(verbose, chalk.blue(`Storing ${processedComments.length} processed comments in database...`));
-        const storedCount = await storePRCommentsBatch(processedComments, projectPath);
+        const storedCount = await storePRCommentsBatch(processedComments, projectPath, { replacePRs: processedPRs });
         verboseLog(verbose, chalk.green(`Successfully stored ${storedCount} PR comments`));
       }
 
@@ -281,11 +281,12 @@ export class PRHistoryAnalyzer {
    * @param {Function|null} [options.onProgress=null] - Optional progress callback
    * @param {string} [options.projectPath=process.cwd()] - Project path used for database filtering
    * @param {boolean} [options.verbose=false] - Enable verbose progress logging
-   * @returns {Promise<Array>} Array of processed comments
+   * @returns {Promise<{comments: Array, processedPRs: Array}>} Processed comments and fully fetched PR metadata
    */
   async processPRComments(prs, options = {}) {
     const { onProgress, projectPath = process.cwd(), verbose = false } = options;
     const allProcessedComments = [];
+    const processedPRs = [];
     let totalComments = 0;
     let processedComments = 0;
     let failedComments = 0;
@@ -293,23 +294,23 @@ export class PRHistoryAnalyzer {
     verboseLog(verbose, chalk.blue(`Processing comments for ${prs.length} PRs...`));
     verboseLog(verbose, chalk.cyan(`This may take several minutes for large repositories...`));
 
-    // Get processed PR date range to skip already processed PRs
+    // Get exact processed PR state to skip only PRs that are already stored and unchanged
     verboseLog(verbose, chalk.blue(`Checking for already processed PRs...`));
-    const { oldestPR, newestPR } = await getProcessedPRDateRange(this.progress.repository, projectPath);
+    const processedPRSyncState = await getProcessedPRSyncState(this.progress.repository, projectPath);
 
     let skippedPRs = 0;
     let prsToProcess = prs;
 
-    if (oldestPR && newestPR) {
-      verboseLog(verbose, chalk.blue(`Found processed PR range: ${oldestPR} to ${newestPR}`));
+    if (processedPRSyncState.processedPRs.size > 0) {
+      verboseLog(verbose, chalk.blue(`Found stored state for ${processedPRSyncState.processedPRs.size} processed PRs`));
       prsToProcess = prs.filter((pr) => {
-        const shouldSkip = shouldSkipPR(pr, oldestPR, newestPR);
+        const shouldSkip = shouldSkipPR(pr, processedPRSyncState);
         if (shouldSkip) {
           skippedPRs++;
         }
         return !shouldSkip;
       });
-      verboseLog(verbose, chalk.green(`Skipping ${skippedPRs} already processed PRs, processing ${prsToProcess.length} new PRs`));
+      verboseLog(verbose, chalk.green(`Skipping ${skippedPRs} unchanged processed PRs, processing ${prsToProcess.length} PRs`));
     }
     else {
       verboseLog(verbose, chalk.blue(`No previously processed PRs found, processing all ${prs.length} PRs`));
@@ -317,7 +318,7 @@ export class PRHistoryAnalyzer {
 
     if (prsToProcess.length === 0) {
       verboseLog(verbose, chalk.yellow(`All PRs have already been processed!`));
-      return allProcessedComments;
+      return { comments: allProcessedComments, processedPRs };
     }
 
     // First pass: count total comments for better progress tracking
@@ -349,7 +350,8 @@ export class PRHistoryAnalyzer {
       const batchPromises = batch.map(async (pr, batchIndex) => {
         try {
           const prIndex = i + batchIndex;
-          const prComments = await this.processSinglePR(pr);
+          const prResult = await this.processSinglePR(pr);
+          const prComments = prResult.comments;
 
           this.progress.setLastProcessed(pr.number);
           this.progress.updatePRs(prsToProcess.length, prIndex + 1);
@@ -363,12 +365,15 @@ export class PRHistoryAnalyzer {
             });
           }
 
-          return prComments;
+          return {
+            comments: prComments,
+            processedPR: { repository: this.progress.repository, prNumber: pr.number, commentIds: prResult.commentIds },
+          };
         }
         catch (error) {
           console.error(chalk.red(`Error processing PR #${pr.number}: ${error.message}`));
           this.progress.addError(error, `PR #${pr.number}`);
-          return [];
+          return { comments: [], processedPR: null };
         }
       });
 
@@ -377,13 +382,17 @@ export class PRHistoryAnalyzer {
 
       // Flatten and collect results
       let batchCommentCount = 0;
-      for (const prComments of batchResults) {
+      for (const batchResult of batchResults) {
+        const prComments = batchResult.comments;
         totalComments += prComments.length;
         const validComments = prComments.filter((comment) => comment !== null);
         processedComments += validComments.length;
         failedComments += prComments.length - validComments.length;
         allProcessedComments.push(...validComments);
         batchCommentCount += prComments.length;
+        if (batchResult.processedPR) {
+          processedPRs.push(batchResult.processedPR);
+        }
       }
 
       const batchDuration = (Date.now() - batchStartTime) / 1000;
@@ -418,14 +427,14 @@ export class PRHistoryAnalyzer {
       verboseLog(verbose, chalk.yellow(`Failed to process ${failedComments} comments`));
     }
 
-    return allProcessedComments;
+    return { comments: allProcessedComments, processedPRs };
   }
 
   /**
    * Process comments for a single PR
    * @private
    * @param {Object} pr - PR object
-   * @returns {Promise<Array>} Array of processed comments
+   * @returns {Promise<{comments: Array, commentIds: Array<string>}>} Processed comments and all live fetched comment IDs
    */
   async processSinglePR(pr) {
     try {
@@ -443,9 +452,13 @@ export class PRHistoryAnalyzer {
         ...reviewComments.map((comment) => ({ ...comment, type: 'review' })),
         ...issueComments.map((comment) => ({ ...comment, type: 'issue' })),
       ];
+      const commentIds = allComments
+        .map((comment) => comment.id)
+        .filter((id) => id !== null && id !== undefined)
+        .map(String);
 
       if (allComments.length === 0) {
-        return [];
+        return { comments: [], commentIds };
       }
 
       // Create PR context
@@ -453,13 +466,14 @@ export class PRHistoryAnalyzer {
         pr: {
           number: pr.number,
           repository: this.progress.repository,
+          updated_at: pr.updated_at || pr.merged_at || pr.created_at || null,
         },
         files: prFiles,
       };
 
       // Process comments using comment processor
       const processedComments = await this.commentProcessor.processBatch(allComments, prContext);
-      return processedComments;
+      return { comments: processedComments, commentIds };
     }
     catch (error) {
       console.error(chalk.red(`Error processing PR #${pr.number}: ${error.message}`));

--- a/src/pr-history/analyzer.test.js
+++ b/src/pr-history/analyzer.test.js
@@ -1,5 +1,5 @@
 import { PRHistoryAnalyzer } from './analyzer.js';
-import { clearPRComments, getPRCommentsStats, storePRCommentsBatch } from './database.js';
+import { clearPRComments, getPRCommentsStats, getProcessedPRSyncState, shouldSkipPR, storePRCommentsBatch } from './database.js';
 
 vi.mock('./comment-processor.js', () => ({
   PRCommentProcessor: class {
@@ -17,7 +17,7 @@ vi.mock('./database.js', () => ({
     authors: {},
     repositories: {},
   }),
-  getProcessedPRDateRange: vi.fn().mockResolvedValue({ oldestPR: null, newestPR: null }),
+  getProcessedPRSyncState: vi.fn().mockResolvedValue({ processedPRs: new Map() }),
   shouldSkipPR: vi.fn().mockReturnValue(false),
   storePRCommentsBatch: vi.fn().mockResolvedValue(0),
 }));
@@ -39,6 +39,8 @@ describe('PRHistoryAnalyzer', () => {
 
     analyzer = new PRHistoryAnalyzer();
     analyzer.initialize('test-token');
+    shouldSkipPR.mockReset().mockReturnValue(false);
+    getProcessedPRSyncState.mockReset().mockResolvedValue({ processedPRs: new Map() });
   });
 
   afterEach(() => {
@@ -117,7 +119,37 @@ describe('PRHistoryAnalyzer', () => {
 
       await analyzer.analyzeRepository('owner/repo');
 
-      expect(storePRCommentsBatch).toHaveBeenCalled();
+      expect(storePRCommentsBatch).toHaveBeenCalledWith([{ id: '1', comment_text: 'Comment', comment_embedding: [] }], expect.any(String), {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 1, commentIds: ['1'] }],
+      });
+    });
+
+    it('should replace stored PR comments when a reprocessed PR now has no comments', async () => {
+      const prs = [{ number: 1, merged_at: '2024-01-01' }];
+      analyzer.githubClient.fetchAllPRs.mockResolvedValue(prs);
+      analyzer.githubClient.getPRReviewComments.mockResolvedValue([]);
+      analyzer.githubClient.getPRIssueComments.mockResolvedValue([]);
+
+      await analyzer.analyzeRepository('owner/repo');
+
+      expect(storePRCommentsBatch).toHaveBeenCalledWith([], expect.any(String), {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 1, commentIds: [] }],
+      });
+    });
+
+    it('should filter using exact PR sync state', async () => {
+      const prs = [{ number: 1, merged_at: '2024-01-01', updated_at: '2024-01-03' }];
+      const processedPRs = new Map([
+        [1, { latestCommentAt: '2024-01-02T00:00:00.000Z', latestPRUpdatedAt: '2024-01-03T00:00:00.000Z', commentCount: 1 }],
+      ]);
+      analyzer.githubClient.fetchAllPRs.mockResolvedValue(prs);
+      getProcessedPRSyncState.mockResolvedValue({ processedPRs });
+      shouldSkipPR.mockReturnValue(false);
+
+      await analyzer.analyzeRepository('owner/repo');
+
+      expect(shouldSkipPR).toHaveBeenCalledWith(prs[0], { processedPRs });
+      expect(analyzer.githubClient.getPRReviewComments).toHaveBeenCalledWith('owner', 'repo', 1);
     });
 
     it('should call onProgress callback', async () => {
@@ -172,7 +204,7 @@ describe('PRHistoryAnalyzer', () => {
       expect(analyzer.commentProcessor.processBatch).toHaveBeenCalled();
     });
 
-    it('should return empty array when no comments', async () => {
+    it('should return empty comments and IDs when no comments', async () => {
       analyzer.progress = { repository: 'owner/repo' };
 
       analyzer.githubClient.getPRReviewComments.mockResolvedValue([]);
@@ -181,7 +213,7 @@ describe('PRHistoryAnalyzer', () => {
 
       const result = await analyzer.processSinglePR({ number: 1 });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ comments: [], commentIds: [] });
     });
   });
 

--- a/src/pr-history/comment-processor.js
+++ b/src/pr-history/comment-processor.js
@@ -177,6 +177,7 @@ export class PRCommentProcessor {
       author: comment.user?.login || 'unknown',
       created_at: comment.created_at,
       updated_at: comment.updated_at,
+      pr_updated_at: prContext.pr?.updated_at || null,
       review_id: comment.pull_request_review_id?.toString() || null,
       review_state: comment.review_state || null,
     };

--- a/src/pr-history/comment-processor.test.js
+++ b/src/pr-history/comment-processor.test.js
@@ -42,7 +42,7 @@ describe('PRCommentProcessor', () => {
         pull_request_review_id: 67890,
       };
       const prContext = {
-        pr: { number: 42, repository: 'owner/repo' },
+        pr: { number: 42, repository: 'owner/repo', updated_at: '2024-01-03T00:00:00Z' },
       };
 
       const metadata = processor.extractMetadata(comment, prContext);
@@ -52,6 +52,7 @@ describe('PRCommentProcessor', () => {
       expect(metadata.repository).toBe('owner/repo');
       expect(metadata.author).toBe('testuser');
       expect(metadata.comment_type).toBe('review');
+      expect(metadata.pr_updated_at).toBe('2024-01-03T00:00:00Z');
     });
 
     it('should handle missing user gracefully', () => {

--- a/src/pr-history/database.js
+++ b/src/pr-history/database.js
@@ -14,6 +14,7 @@ import { EMBEDDING_DIMENSIONS, TABLE_NAMES } from '../embeddings/constants.js';
 import { getDefaultEmbeddingsSystem } from '../embeddings/factory.js';
 import { verboseLog } from '../utils/logging.js';
 import { truncateToTokenLimit, cleanupTokenizer } from '../utils/mobilebert-tokenizer.js';
+import { escapeSqlString } from '../utils/string-utils.js';
 
 // Create embeddings system instance
 const embeddingsSystem = getDefaultEmbeddingsSystem();
@@ -21,21 +22,29 @@ const embeddingsSystem = getDefaultEmbeddingsSystem();
 // Import constants from embeddings.js to avoid duplication
 const { PR_COMMENTS } = TABLE_NAMES;
 const PR_COMMENTS_TABLE = PR_COMMENTS;
+const PR_SYNC_STATE_BATCH_SIZE = 10000;
+const STALE_COMMENT_DELETE_BATCH_SIZE = 500;
 
 /**
  * Store multiple PR comments in batch
  * @param {Array<Object>} commentsData - Array of processed comment data
  * @param {string} projectPath - Project path for isolation (optional, defaults to cwd)
+ * @param {Object} options - Storage options
+ * @param {Array<Object>} [options.replacePRs=[]] - PRs that were fully reprocessed and should have stale comments removed
  * @returns {Promise<number>} Number of successfully stored comments
  */
-export async function storePRCommentsBatch(commentsData, projectPath = process.cwd()) {
-  if (!Array.isArray(commentsData) || commentsData.length === 0) {
+export async function storePRCommentsBatch(commentsData, projectPath = process.cwd(), options = {}) {
+  const replacePRs = Array.isArray(options.replacePRs) ? options.replacePRs : [];
+  if ((!Array.isArray(commentsData) || commentsData.length === 0) && replacePRs.length === 0) {
     return 0;
   }
 
   let successCount = 0;
   const batchSize = 100;
   const resolvedProjectPath = path.resolve(projectPath);
+  const sourceComments = Array.isArray(commentsData) ? commentsData : [];
+  const validRecords = [];
+  const liveIdsByPR = collectLiveCommentIdsByPR(sourceComments, replacePRs);
 
   try {
     const table = await embeddingsSystem.getPRCommentsTable();
@@ -44,9 +53,8 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
       throw new Error(`Table ${PR_COMMENTS_TABLE} not found`);
     }
 
-    for (let i = 0; i < commentsData.length; i += batchSize) {
-      const batch = commentsData.slice(i, i + batchSize);
-      const validRecords = [];
+    for (let i = 0; i < sourceComments.length; i += batchSize) {
+      const batch = sourceComments.slice(i, i + batchSize);
 
       for (const commentData of batch) {
         try {
@@ -84,6 +92,7 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
             author: commentData.author || 'unknown',
             created_at: commentData.created_at || new Date().toISOString(),
             updated_at: commentData.updated_at || null,
+            pr_updated_at: commentData.pr_updated_at || null,
             review_id: commentData.review_id || null,
             review_state: commentData.review_state || null,
 
@@ -98,36 +107,38 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
           console.warn(chalk.yellow(`Error preparing record for ${commentData.id}: ${recordError.message}`));
         }
       }
+    }
 
-      if (validRecords.length > 0) {
-        try {
-          await table.add(validRecords);
-          successCount += validRecords.length;
-
-          // Optimize table to sync indices with data and prevent TakeExec panics
-          try {
-            await table.optimize();
-          }
-          catch (optimizeError) {
-            if (optimizeError.message && optimizeError.message.includes('legacy format')) {
-              verboseLog(
-                {},
-                chalk.yellow(`Skipping optimization due to legacy index format - will be auto-upgraded during normal operations`)
-              );
-            }
-            else {
-              console.warn(chalk.yellow(`Warning: Failed to optimize PR comments table after adding records: ${optimizeError.message}`));
-            }
-          }
-
-          verboseLog({}, chalk.green(`Stored batch of ${validRecords.length} PR comments`));
+    const failedStoragePRKeys = new Set();
+    for (let i = 0; i < validRecords.length; i += batchSize) {
+      const batch = validRecords.slice(i, i + batchSize);
+      try {
+        if (typeof table.mergeInsert === 'function') {
+          await table.mergeInsert(['id', 'project_path']).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute(batch);
         }
-        catch (batchError) {
-          console.error(chalk.red(`Error storing batch: ${batchError.message}`));
+        else {
+          await table.add(batch);
         }
+        successCount += batch.length;
+        verboseLog({}, chalk.green(`Stored batch of ${batch.length} PR comments`));
+      }
+      catch (batchError) {
+        for (const record of batch) {
+          failedStoragePRKeys.add(getPRStorageKey(record.repository, record.pr_number));
+        }
+        console.error(chalk.red(`Error storing batch: ${batchError.message}`));
       }
     }
-    if (successCount > 0) {
+
+    let staleCleanupAttempted = false;
+    if (replacePRs.length > 0) {
+      staleCleanupAttempted = await deleteStalePRComments(table, replacePRs, liveIdsByPR, resolvedProjectPath, {
+        failedStoragePRKeys,
+      });
+    }
+
+    if (successCount > 0 || staleCleanupAttempted) {
+      await optimizePRCommentsTable(table);
       await embeddingsSystem.updatePRCommentsIndex();
     }
   }
@@ -136,6 +147,145 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
   }
 
   return successCount;
+}
+
+async function optimizePRCommentsTable(table) {
+  try {
+    await table.optimize();
+  }
+  catch (optimizeError) {
+    if (optimizeError.message && optimizeError.message.includes('legacy format')) {
+      verboseLog({}, chalk.yellow(`Skipping optimization due to legacy index format - will be auto-upgraded during normal operations`));
+    }
+    else {
+      console.warn(chalk.yellow(`Warning: Failed to optimize PR comments table after adding records: ${optimizeError.message}`));
+    }
+  }
+}
+
+async function deleteStalePRComments(table, replacePRs, liveIdsByPR, resolvedProjectPath, options = {}) {
+  const failedStoragePRKeys = options.failedStoragePRKeys || new Set();
+  let attempted = false;
+  const seenPRs = new Set();
+  for (const pr of replacePRs) {
+    const repository = pr.repository || pr.repo;
+    const prNumber = Number(pr.prNumber ?? pr.pr_number ?? pr.number);
+    if (!repository || !Number.isFinite(prNumber)) {
+      continue;
+    }
+
+    const key = getPRStorageKey(repository, prNumber);
+    if (seenPRs.has(key)) {
+      continue;
+    }
+    seenPRs.add(key);
+    if (failedStoragePRKeys.has(key)) {
+      continue;
+    }
+
+    const filters = [
+      `repository = '${escapeSqlString(repository)}'`,
+      `project_path = '${escapeSqlString(resolvedProjectPath)}'`,
+      `pr_number = ${prNumber}`,
+    ];
+    const baseFilter = filters.join(' AND ');
+    const liveIds = liveIdsByPR.get(key) || new Set();
+
+    try {
+      if (liveIds.size === 0) {
+        // Empty live ID sets come from successful API responses for PRs that currently have no comments.
+        await table.delete(baseFilter);
+        attempted = true;
+        continue;
+      }
+
+      const storedIds = await getStoredPRCommentIds(table, baseFilter);
+      const staleIds = storedIds.filter((id) => !liveIds.has(id));
+      for (let i = 0; i < staleIds.length; i += STALE_COMMENT_DELETE_BATCH_SIZE) {
+        const staleIdBatch = staleIds.slice(i, i + STALE_COMMENT_DELETE_BATCH_SIZE);
+        const staleIdFilter = staleIdBatch.map((id) => `'${escapeSqlString(id)}'`).join(', ');
+        await table.delete(`${baseFilter} AND id IN (${staleIdFilter})`);
+        attempted = true;
+      }
+    }
+    catch (deleteError) {
+      console.warn(chalk.yellow(`Warning: Could not remove stale PR comments for #${prNumber}: ${deleteError.message}`));
+    }
+  }
+
+  return attempted;
+}
+
+async function getStoredPRCommentIds(table, whereClause) {
+  const ids = [];
+  let offset = 0;
+  while (true) {
+    const batch = await table
+      .query()
+      .where(whereClause)
+      .select(['id'])
+      .orderBy([{ column: 'id', order: 'asc' }])
+      .limit(PR_SYNC_STATE_BATCH_SIZE)
+      .offset(offset)
+      .toArray();
+
+    ids.push(
+      ...batch
+        .map((row) => row.id)
+        .filter(Boolean)
+        .map(String)
+    );
+    if (batch.length < PR_SYNC_STATE_BATCH_SIZE) {
+      break;
+    }
+    offset += batch.length;
+  }
+
+  return ids;
+}
+
+function collectLiveCommentIdsByPR(sourceComments, replacePRs) {
+  const liveIdsByPR = new Map();
+  for (const pr of replacePRs) {
+    const repository = pr.repository || pr.repo;
+    const prNumber = Number(pr.prNumber ?? pr.pr_number ?? pr.number);
+    if (!repository || !Number.isFinite(prNumber)) {
+      continue;
+    }
+
+    const key = getPRStorageKey(repository, prNumber);
+    if (!liveIdsByPR.has(key)) {
+      liveIdsByPR.set(key, new Set());
+    }
+
+    if (Array.isArray(pr.commentIds)) {
+      for (const id of pr.commentIds) {
+        if (id !== null && id !== undefined) {
+          liveIdsByPR.get(key).add(String(id));
+        }
+      }
+    }
+  }
+
+  for (const commentData of sourceComments) {
+    const repository = commentData.repository || commentData.repo;
+    const prNumber = Number(commentData.prNumber ?? commentData.pr_number ?? commentData.number);
+    if (!commentData.id || !repository || !Number.isFinite(prNumber)) {
+      continue;
+    }
+
+    const key = getPRStorageKey(repository, prNumber);
+    if (!liveIdsByPR.has(key)) {
+      liveIdsByPR.set(key, new Set());
+    }
+    liveIdsByPR.get(key).add(String(commentData.id));
+  }
+
+  return liveIdsByPR;
+}
+
+function getPRStorageKey(repository, prNumber) {
+  return `${repository}#${Number(prNumber)}`;
 }
 
 /**
@@ -164,9 +314,9 @@ export async function getPRCommentsStats(repository = null, projectPath = proces
 
     const resolvedProjectPath = path.resolve(projectPath);
 
-    const filters = [`project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`];
+    const filters = [`project_path = '${escapeSqlString(resolvedProjectPath)}'`];
     if (repository) {
-      filters.push(`repository = '${repository.replace(/'/g, "''")}'`);
+      filters.push(`repository = '${escapeSqlString(repository)}'`);
     }
 
     const whereClause = filters.join(' AND ');
@@ -285,77 +435,104 @@ export async function getPRCommentsStats(repository = null, projectPath = proces
 }
 
 /**
- * Get the date range of processed PRs for a repository
+ * Get exact processed PR sync state for a repository.
  * @param {string} repository - Repository in format "owner/repo"
  * @param {string} projectPath - Project path for filtering (optional, defaults to cwd)
- * @returns {Promise<{oldestPR: string|null, newestPR: string|null}>} Date range of processed PRs
+ * @returns {Promise<{processedPRs: Map<number, {latestCommentAt: string|null, latestPRUpdatedAt: string|null, commentCount: number}>}>} Processed PR state
  */
-export async function getProcessedPRDateRange(repository, projectPath = process.cwd()) {
+export async function getProcessedPRSyncState(repository, projectPath = process.cwd()) {
   try {
     const table = await embeddingsSystem.getPRCommentsTable();
 
     if (!table) {
-      return { oldestPR: null, newestPR: null };
+      return { processedPRs: new Map() };
     }
 
     const resolvedProjectPath = path.resolve(projectPath);
-    const whereClause = `repository = '${repository.replace(/'/g, "''")}' AND project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`;
-
-    // Get all unique PR numbers and their creation dates
-    const results = await table.query().where(whereClause).limit(10000).toArray();
-
-    if (results.length === 0) {
-      return { oldestPR: null, newestPR: null };
+    const whereClause = `repository = '${escapeSqlString(repository)}' AND project_path = '${escapeSqlString(resolvedProjectPath)}'`;
+    const results = [];
+    let offset = 0;
+    while (true) {
+      const batch = await table
+        .query()
+        .where(whereClause)
+        .select(['id', 'pr_number', 'created_at', 'updated_at', 'pr_updated_at'])
+        .orderBy([{ column: 'id', order: 'asc' }])
+        .limit(PR_SYNC_STATE_BATCH_SIZE)
+        .offset(offset)
+        .toArray();
+      results.push(...batch);
+      if (batch.length < PR_SYNC_STATE_BATCH_SIZE) {
+        break;
+      }
+      offset += batch.length;
     }
+    const processedPRs = new Map();
 
-    // Extract unique PRs with their dates
-    const prDates = new Map();
-    results.forEach((comment) => {
-      if (comment.pr_number && comment.created_at) {
-        const prNumber = comment.pr_number;
-        const commentDate = new Date(comment.created_at);
+    for (const comment of results) {
+      if (!comment.pr_number) {
+        continue;
+      }
 
-        if (!prDates.has(prNumber) || commentDate < prDates.get(prNumber)) {
-          prDates.set(prNumber, commentDate);
+      const prNumber = Number(comment.pr_number);
+      const existing = processedPRs.get(prNumber) || { latestCommentAt: null, latestPRUpdatedAt: null, commentCount: 0 };
+      const commentTimestamp = comment.updated_at || comment.created_at;
+      const prTimestamp = comment.pr_updated_at;
+
+      existing.commentCount += 1;
+      if (commentTimestamp) {
+        const timestampDate = new Date(commentTimestamp);
+        const existingDate = existing.latestCommentAt ? new Date(existing.latestCommentAt) : null;
+        if (!Number.isNaN(timestampDate.getTime()) && (!existingDate || timestampDate > existingDate)) {
+          existing.latestCommentAt = timestampDate.toISOString();
         }
       }
-    });
+      if (prTimestamp) {
+        const prUpdatedDate = new Date(prTimestamp);
+        const existingPRUpdatedDate = existing.latestPRUpdatedAt ? new Date(existing.latestPRUpdatedAt) : null;
+        if (!Number.isNaN(prUpdatedDate.getTime()) && (!existingPRUpdatedDate || prUpdatedDate > existingPRUpdatedDate)) {
+          existing.latestPRUpdatedAt = prUpdatedDate.toISOString();
+        }
+      }
 
-    if (prDates.size === 0) {
-      return { oldestPR: null, newestPR: null };
+      processedPRs.set(prNumber, existing);
     }
 
-    const dates = Array.from(prDates.values()).sort((a, b) => a - b);
-    const oldestPR = dates[0].toISOString();
-    const newestPR = dates[dates.length - 1].toISOString();
-
-    verboseLog({}, chalk.blue(`Processed PR date range: ${oldestPR} to ${newestPR} (${prDates.size} PRs)`));
-    return { oldestPR, newestPR };
+    verboseLog({}, chalk.blue(`Found stored PR sync state for ${processedPRs.size} PRs`));
+    return { processedPRs };
   }
   catch (error) {
-    console.error(chalk.red(`Error getting processed PR date range: ${error.message}`));
-    return { oldestPR: null, newestPR: null };
+    console.error(chalk.red(`Error getting processed PR sync state: ${error.message}`));
+    return { processedPRs: new Map() };
   }
 }
 
 /**
- * Check if a PR should be skipped based on processed date range
+ * Check if a PR should be skipped based on exact processed sync state.
  * @param {Object} pr - PR object with merged_at or created_at date
- * @param {string} oldestPR - Oldest processed PR date (ISO string)
- * @param {string} newestPR - Newest processed PR date (ISO string)
+ * @param {Object} processedPRSyncState - Exact processed PR sync state
  * @returns {boolean} True if PR should be skipped
  */
-export function shouldSkipPR(pr, oldestPR, newestPR) {
-  if (!oldestPR || !newestPR || !pr) {
+export function shouldSkipPR(pr, processedPRSyncState) {
+  const processedPRs = processedPRSyncState?.processedPRs;
+  const prNumber = Number(pr?.number || pr?.pr_number);
+  const processedState = processedPRs instanceof Map ? processedPRs.get(prNumber) : null;
+  if (!pr || !processedState) {
     return false;
   }
 
-  const prDate = new Date(pr.merged_at || pr.created_at || pr.updated_at);
-  const oldestDate = new Date(oldestPR);
-  const newestDate = new Date(newestPR);
+  if (!processedState.latestPRUpdatedAt) {
+    // Legacy rows predate pr_updated_at; keep them as processed markers to avoid a one-time full history re-crawl.
+    return Boolean(processedState.latestCommentAt);
+  }
 
-  // Skip if PR date falls within the already processed range
-  return prDate >= oldestDate && prDate <= newestDate;
+  const latestStoredDate = new Date(processedState.latestPRUpdatedAt);
+  const latestPRDate = new Date(pr.updated_at || pr.merged_at || pr.created_at);
+  if (Number.isNaN(latestStoredDate.getTime()) || Number.isNaN(latestPRDate.getTime())) {
+    return false;
+  }
+
+  return latestPRDate <= latestStoredDate;
 }
 
 /**
@@ -373,7 +550,7 @@ export async function clearPRComments(repository, projectPath = process.cwd()) {
     }
 
     const resolvedProjectPath = path.resolve(projectPath);
-    const deleteQuery = `repository = '${repository.replace(/'/g, "''")}' AND project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`;
+    const deleteQuery = `repository = '${escapeSqlString(repository)}' AND project_path = '${escapeSqlString(resolvedProjectPath)}'`;
     const countBefore = await table.countRows(deleteQuery);
 
     await table.delete(deleteQuery);
@@ -401,11 +578,11 @@ export async function hasPRComments(repository, projectPath = process.cwd()) {
       return false;
     }
 
-    let whereClause = `repository = '${repository.replace(/'/g, "''")}'`;
+    let whereClause = `repository = '${escapeSqlString(repository)}'`;
 
     if (projectPath !== null) {
       const resolvedProjectPath = path.resolve(projectPath);
-      whereClause += ` AND project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`;
+      whereClause += ` AND project_path = '${escapeSqlString(resolvedProjectPath)}'`;
     }
 
     const count = await table.countRows(whereClause);
@@ -433,7 +610,7 @@ export async function getLastAnalysisTimestamp(repository, projectPath) {
 
     const resolvedProjectPath = path.resolve(projectPath);
 
-    const filters = [`repository = '${repository.replace(/'/g, "''")}'`, `project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`];
+    const filters = [`repository = '${escapeSqlString(repository)}'`, `project_path = '${escapeSqlString(resolvedProjectPath)}'`];
 
     const results = await table
       .query()
@@ -746,7 +923,7 @@ export async function findRelevantPRComments(reviewFileContent, options = {}) {
 
     // Create project-specific WHERE clause for filtering
     const resolvedProjectPath = path.resolve(projectPath);
-    const projectWhereClause = `project_path = '${resolvedProjectPath.replace(/'/g, "''")}'`;
+    const projectWhereClause = `project_path = '${escapeSqlString(resolvedProjectPath)}'`;
 
     verboseLog(options, chalk.blue(`🔒 Project isolation: filtering by project_path = '${resolvedProjectPath}'`));
 

--- a/src/pr-history/database.test.js
+++ b/src/pr-history/database.test.js
@@ -1,25 +1,36 @@
-import { createMockPRSearchResult, generateShouldSkipPRTestCases } from '../test-utils/fixtures.js';
+import { createMockPRSearchResult } from '../test-utils/fixtures.js';
 import {
   shouldSkipPR,
   storePRCommentsBatch,
   getPRCommentsStats,
   clearPRComments,
   hasPRComments,
-  getProcessedPRDateRange,
+  getProcessedPRSyncState,
   getLastAnalysisTimestamp,
   findRelevantPRComments,
   cleanupClassifier,
 } from './database.js';
 
+const mockMergeBuilder = vi.hoisted(() => {
+  const builder = {};
+  builder.whenMatchedUpdateAll = vi.fn(() => builder);
+  builder.whenNotMatchedInsertAll = vi.fn(() => builder);
+  builder.execute = vi.fn().mockResolvedValue(undefined);
+  return builder;
+});
+
 // Create hoisted mock table for embeddings system (must be inline, can't use imported functions)
 const mockTable = vi.hoisted(() => ({
   add: vi.fn().mockResolvedValue(undefined),
+  mergeInsert: vi.fn(() => mockMergeBuilder),
   optimize: vi.fn().mockResolvedValue(undefined),
   countRows: vi.fn().mockResolvedValue(0),
   query: vi.fn().mockReturnValue({
     where: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     select: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
     toArray: vi.fn().mockResolvedValue([]),
   }),
   search: vi.fn().mockReturnValue({
@@ -93,6 +104,8 @@ const setupMockQueryResults = (results) => {
     where: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     select: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
     toArray: vi.fn().mockResolvedValue(results),
   });
 };
@@ -106,6 +119,10 @@ describe('PR History Database', () => {
     mockConsole();
     // Reset mockTable (inline since can't use imported function with hoisted mocks)
     mockTable.add.mockReset().mockResolvedValue(undefined);
+    mockTable.mergeInsert.mockReset().mockReturnValue(mockMergeBuilder);
+    mockMergeBuilder.whenMatchedUpdateAll.mockReset().mockReturnValue(mockMergeBuilder);
+    mockMergeBuilder.whenNotMatchedInsertAll.mockReset().mockReturnValue(mockMergeBuilder);
+    mockMergeBuilder.execute.mockReset().mockResolvedValue(undefined);
     mockTable.optimize.mockReset().mockResolvedValue(undefined);
     mockTable.countRows.mockReset().mockResolvedValue(0);
     mockTable.delete.mockReset().mockResolvedValue(undefined);
@@ -113,6 +130,8 @@ describe('PR History Database', () => {
       where: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
       toArray: vi.fn().mockResolvedValue([]),
     });
     mockTable.search.mockReset().mockReturnValue({
@@ -139,8 +158,28 @@ describe('PR History Database', () => {
   // ==========================================================================
 
   describe('shouldSkipPR', () => {
-    it.each(generateShouldSkipPRTestCases())('should return $expected when $description', ({ pr, oldest, newest, expected }) => {
-      expect(shouldSkipPR(pr, oldest, newest)).toBe(expected);
+    it.each([
+      ['missing sync state', { number: 12, updated_at: '2024-01-20T00:00:00.000Z' }, null, false],
+      ['missing PR', null, { processedPRs: new Map([[12, { latestPRUpdatedAt: '2024-01-20T00:00:00.000Z' }]]) }, false],
+      ['unprocessed PR', { number: 13, updated_at: '2024-01-20T00:00:00.000Z' }, { processedPRs: new Map() }, false],
+    ])('should return expected when %s', (_, pr, syncState, expected) => {
+      expect(shouldSkipPR(pr, syncState)).toBe(expected);
+    });
+
+    it('should skip only exact processed PRs with no newer PR activity', () => {
+      const processedPRs = new Map([
+        [12, { latestCommentAt: '2024-01-10T00:00:00.000Z', latestPRUpdatedAt: '2024-01-20T00:00:00.000Z', commentCount: 2 }],
+      ]);
+
+      expect(shouldSkipPR({ number: 12, updated_at: '2024-01-20T00:00:00.000Z' }, { processedPRs })).toBe(true);
+      expect(shouldSkipPR({ number: 13, updated_at: '2024-01-20T00:00:00.000Z' }, { processedPRs })).toBe(false);
+      expect(shouldSkipPR({ number: 12, updated_at: '2024-01-21T00:00:00.000Z' }, { processedPRs })).toBe(false);
+    });
+
+    it('should skip legacy PR state using stored comments as the processed marker', () => {
+      const processedPRs = new Map([[12, { latestCommentAt: '2024-01-20T00:00:00.000Z', commentCount: 2 }]]);
+
+      expect(shouldSkipPR({ number: 12, updated_at: '2024-01-21T00:00:00.000Z' }, { processedPRs })).toBe(true);
     });
   });
 
@@ -161,7 +200,110 @@ describe('PR History Database', () => {
       const comments = [createValidComment()];
       const result = await storePRCommentsBatch(comments);
       expect(result).toBe(1);
-      expect(mockTable.add).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ comment_text: 'Test comment' })]));
+      expect(mockTable.mergeInsert).toHaveBeenCalledWith(['id', 'project_path']);
+      expect(mockMergeBuilder.whenMatchedUpdateAll).toHaveBeenCalled();
+      expect(mockMergeBuilder.whenNotMatchedInsertAll).toHaveBeenCalled();
+      expect(mockMergeBuilder.execute).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ comment_text: 'Test comment' })])
+      );
+    });
+
+    it('should upsert comments with the same id without deleting existing rows first', async () => {
+      const comments = [createValidComment({ id: "comment-'1" })];
+      const result = await storePRCommentsBatch(comments, "/project/that's/deep");
+
+      expect(result).toBe(1);
+      expect(mockTable.delete).not.toHaveBeenCalled();
+      expect(mockMergeBuilder.execute).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ id: "comment-'1" })]));
+    });
+
+    it('should remove stale comments for fully reprocessed PRs after upsert succeeds', async () => {
+      const comments = [createValidComment({ id: "comment-'1", repository: 'owner/repo', pr_number: 7 })];
+      setupMockQueryResults([{ id: "comment-'1" }, { id: "stale-'2" }]);
+
+      const result = await storePRCommentsBatch(comments, "/project/that's/deep", {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 7 }],
+      });
+
+      expect(result).toBe(1);
+      expect(mockMergeBuilder.execute).toHaveBeenCalled();
+      expect(mockTable.delete).toHaveBeenCalledWith(
+        "repository = 'owner/repo' AND project_path = '/project/that''s/deep' AND pr_number = 7 AND id IN ('stale-''2')"
+      );
+    });
+
+    it('should keep live comments that were fetched but skipped during validation', async () => {
+      const comments = [
+        createValidComment({ id: 'live-valid', repository: 'owner/repo', pr_number: 7 }),
+        createValidComment({ id: 'live-invalid', repository: 'owner/repo', pr_number: 7, comment_embedding: new Array(256).fill(0.1) }),
+      ];
+      setupMockQueryResults([{ id: 'live-valid' }, { id: 'live-invalid' }, { id: 'stale-deleted' }]);
+
+      const result = await storePRCommentsBatch(comments, '/project', {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 7 }],
+      });
+
+      expect(result).toBe(1);
+      expect(mockTable.delete).toHaveBeenCalledTimes(1);
+      expect(mockTable.delete).toHaveBeenCalledWith(
+        "repository = 'owner/repo' AND project_path = '/project' AND pr_number = 7 AND id IN ('stale-deleted')"
+      );
+    });
+
+    it('should remove all stored comments when a reprocessed PR now has no comments', async () => {
+      const result = await storePRCommentsBatch([], "/project/that's/deep", {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 7 }],
+      });
+
+      expect(result).toBe(0);
+      expect(mockMergeBuilder.execute).not.toHaveBeenCalled();
+      expect(mockTable.delete).toHaveBeenCalledWith(
+        "repository = 'owner/repo' AND project_path = '/project/that''s/deep' AND pr_number = 7"
+      );
+      expect(mockEmbeddingsSystem.updatePRCommentsIndex).toHaveBeenCalled();
+    });
+
+    it('should not delete existing rows when an upsert fails', async () => {
+      mockMergeBuilder.execute.mockRejectedValue(new Error('Database error'));
+
+      const result = await storePRCommentsBatch([createValidComment({ repository: 'owner/repo', pr_number: 7 })], '/project', {
+        replacePRs: [{ repository: 'owner/repo', prNumber: 7 }],
+      });
+
+      expect(result).toBe(0);
+      expect(mockTable.delete).not.toHaveBeenCalled();
+    });
+
+    it('should still clean up unaffected PRs when another PR storage batch fails', async () => {
+      const failedPRComments = Array.from({ length: 100 }, (_, index) =>
+        createValidComment({ id: `failed-${index}`, repository: 'owner/repo', pr_number: 7 })
+      );
+      const successfulComment = createValidComment({ id: 'live-8', repository: 'owner/repo', pr_number: 8 });
+      const comments = [...failedPRComments, successfulComment];
+      const query = {
+        where: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        offset: vi.fn().mockReturnThis(),
+        toArray: vi.fn().mockResolvedValue([{ id: 'live-8' }, { id: 'stale-8' }]),
+      };
+      mockTable.query.mockReturnValue(query);
+      mockMergeBuilder.execute.mockRejectedValueOnce(new Error('Database error')).mockResolvedValueOnce(undefined);
+
+      const result = await storePRCommentsBatch(comments, '/project', {
+        replacePRs: [
+          { repository: 'owner/repo', prNumber: 7 },
+          { repository: 'owner/repo', prNumber: 8 },
+        ],
+      });
+
+      expect(result).toBe(1);
+      expect(query.where).toHaveBeenCalledWith("repository = 'owner/repo' AND project_path = '/project' AND pr_number = 8");
+      expect(mockTable.delete).toHaveBeenCalledTimes(1);
+      expect(mockTable.delete).toHaveBeenCalledWith(
+        "repository = 'owner/repo' AND project_path = '/project' AND pr_number = 8 AND id IN ('stale-8')"
+      );
     });
 
     it('should skip comments with missing required fields', async () => {
@@ -183,7 +325,7 @@ describe('PR History Database', () => {
     });
 
     it('should handle batch storage errors', async () => {
-      mockTable.add.mockRejectedValue(new Error('Database error'));
+      mockMergeBuilder.execute.mockRejectedValue(new Error('Database error'));
       const result = await storePRCommentsBatch([createValidComment()]);
       expect(result).toBe(0);
     });
@@ -339,50 +481,53 @@ describe('PR History Database', () => {
     });
   });
 
-  // ==========================================================================
-  // getProcessedPRDateRange
-  // ==========================================================================
-
-  describe('getProcessedPRDateRange', () => {
-    it.each([
-      ['table not found', () => mockEmbeddingsSystem.getPRCommentsTable.mockResolvedValue(null)],
-      ['no results', () => setupMockQueryResults([])],
-      [
-        'query errors',
-        () =>
-          mockTable.query.mockReturnValue({
-            where: vi.fn().mockReturnThis(),
-            limit: vi.fn().mockReturnThis(),
-            toArray: vi.fn().mockRejectedValue(new Error('Query error')),
-          }),
-      ],
-    ])('should return null dates when %s', async (_, setup) => {
-      setup();
-      const result = await getProcessedPRDateRange('owner/repo');
-      expect(result.oldestPR).toBeNull();
-      expect(result.newestPR).toBeNull();
-    });
-
-    it('should return date range for comments', async () => {
-      const mockComments = [
-        { pr_number: 1, created_at: '2024-01-10T00:00:00Z' },
-        { pr_number: 2, created_at: '2024-01-20T00:00:00Z' },
-        { pr_number: 1, created_at: '2024-01-15T00:00:00Z' },
-      ];
-      setupMockQueryResults(mockComments);
-      const result = await getProcessedPRDateRange('owner/repo');
-      expect(result.oldestPR).toContain('2024-01-10');
-      expect(result.newestPR).toContain('2024-01-20');
-    });
-
-    it('should return null dates when no valid pr_number or created_at', async () => {
+  describe('getProcessedPRSyncState', () => {
+    it('should return exact PR sync state with latest comment timestamps', async () => {
       setupMockQueryResults([
-        { pr_number: null, created_at: '2024-01-15' },
-        { pr_number: 1, created_at: null },
+        { pr_number: 1, created_at: '2024-01-10T00:00:00Z', updated_at: null, pr_updated_at: '2024-01-14T00:00:00Z' },
+        { pr_number: 1, created_at: '2024-01-12T00:00:00Z', updated_at: '2024-01-15T00:00:00Z', pr_updated_at: '2024-01-16T00:00:00Z' },
+        { pr_number: 2, created_at: '2024-01-20T00:00:00Z', updated_at: null, pr_updated_at: '2024-01-21T00:00:00Z' },
       ]);
-      const result = await getProcessedPRDateRange('owner/repo');
-      expect(result.oldestPR).toBeNull();
-      expect(result.newestPR).toBeNull();
+
+      const result = await getProcessedPRSyncState('owner/repo');
+
+      expect(result.processedPRs.size).toBe(2);
+      expect(result.processedPRs.get(1)).toEqual({
+        latestCommentAt: '2024-01-15T00:00:00.000Z',
+        latestPRUpdatedAt: '2024-01-16T00:00:00.000Z',
+        commentCount: 2,
+      });
+      expect(result.processedPRs.get(2)).toEqual({
+        latestCommentAt: '2024-01-20T00:00:00.000Z',
+        latestPRUpdatedAt: '2024-01-21T00:00:00.000Z',
+        commentCount: 1,
+      });
+    });
+
+    it('should read all sync rows in pages with a narrow projection', async () => {
+      const firstPage = Array.from({ length: 10000 }, (_, index) => ({
+        pr_number: index + 1,
+        created_at: '2024-01-10T00:00:00Z',
+        pr_updated_at: '2024-01-11T00:00:00Z',
+      }));
+      const secondPage = [{ pr_number: 10001, created_at: '2024-01-12T00:00:00Z', pr_updated_at: '2024-01-13T00:00:00Z' }];
+      const query = {
+        where: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        offset: vi.fn().mockReturnThis(),
+        toArray: vi.fn().mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage),
+      };
+      mockTable.query.mockReturnValue(query);
+
+      const result = await getProcessedPRSyncState('owner/repo');
+
+      expect(result.processedPRs.size).toBe(10001);
+      expect(query.select).toHaveBeenCalledWith(['id', 'pr_number', 'created_at', 'updated_at', 'pr_updated_at']);
+      expect(query.orderBy).toHaveBeenCalledWith([{ column: 'id', order: 'asc' }]);
+      expect(query.offset).toHaveBeenNthCalledWith(1, 0);
+      expect(query.offset).toHaveBeenNthCalledWith(2, 10000);
     });
   });
 

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -722,7 +722,7 @@ function prepareContextForLLM(filePath, content, language, finalCodeExamples, fi
     context: contextSections,
     codeExamples,
     guidelineSnippets,
-    customDocs: relevantCustomDocChunks || customDocs, // Use relevant chunks if available, fallback to full docs
+    customDocs: relevantCustomDocChunks?.length > 0 ? relevantCustomDocChunks : customDocs, // Use relevant chunks if available, fallback to full docs
     feedbackContext: generateFeedbackContext(dismissedPatterns), // Add feedback context for LLM
     projectSummary: projectSummary, // Add project architecture summary
     metadata: {
@@ -1729,7 +1729,12 @@ async function performHolisticPRAnalysis(options) {
           items: unifiedContext.prComments.slice(0, 10),
         },
       ],
-      customDocs: unifiedContext.customDocChunks || options.relevantCustomDocChunks || customDocs, // Use unified chunks first, then relevant chunks, then full docs
+      customDocs:
+        unifiedContext.customDocChunks?.length > 0
+          ? unifiedContext.customDocChunks
+          : options.relevantCustomDocChunks?.length > 0
+            ? options.relevantCustomDocChunks
+            : customDocs, // Use chunks only when available, then fall back to full docs
       projectSummary: projectSummary, // Add project architecture summary
       metadata: {
         hasCodeExamples: unifiedContext.codeExamples.length > 0,

--- a/src/rag-analyzer.test.js
+++ b/src/rag-analyzer.test.js
@@ -762,6 +762,19 @@ describe('rag-analyzer', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should fall back to full custom docs when no relevant chunks are found', async () => {
+      mockEmbeddingsSystem.getExistingCustomDocumentChunks.mockResolvedValue([
+        { id: 'existing', content: 'Existing indexed chunk', document_title: 'Indexed Doc', chunk_index: 0 },
+      ]);
+      mockEmbeddingsSystem.findRelevantCustomDocChunks.mockResolvedValue([]);
+
+      await runAnalysis('/test/file.js', {
+        customDocs: [{ content: 'Mandatory internal review rule', document_title: 'Internal Standards' }],
+      });
+
+      expect(llm.sendPromptToClaude).toHaveBeenCalledWith(expect.stringContaining('Mandatory internal review rule'), expect.any(Object));
+    });
+
     it('should log selected chunks when verbose', async () => {
       mockEmbeddingsSystem.findRelevantCustomDocChunks.mockResolvedValue([
         { id: 'chunk1', content: 'Guidelines', document_title: 'Guide', chunk_index: 0, similarity: 0.85 },

--- a/src/rag-review.js
+++ b/src/rag-review.js
@@ -230,7 +230,17 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
     verboseLog(verbose, chalk.gray(`Base branch: ${baseBranch}, Target branch: ${targetBranch}`));
 
     const prFiles = [];
-    for (const filePath of filesToReview) {
+    if (options.preloadedPRFiles?.length > 0) {
+      prFiles.push(
+        ...options.preloadedPRFiles.map((file) => ({
+          ...file,
+          baseBranch: file.baseBranch || baseBranch,
+          targetBranch: file.targetBranch || targetBranch,
+        }))
+      );
+    }
+
+    for (const filePath of options.preloadedPRFiles?.length > 0 ? [] : filesToReview) {
       try {
         // Check if the file should be processed before fetching its content from git
         if (!shouldProcessFile(filePath, '', options)) {
@@ -596,6 +606,7 @@ async function reviewPRChunk(chunk, sharedContext, options, chunkNumber, totalCh
 
   // Skip chunking decision for chunk reviews to prevent infinite recursion
   const skipChunkingOptions = { ...chunkOptions, skipChunking: true };
+  skipChunkingOptions.preloadedPRFiles = chunk.files;
 
   return await reviewPullRequestWithCrossFileContext(chunkFilePaths, skipChunkingOptions);
 }

--- a/src/test-utils/fixtures.js
+++ b/src/test-utils/fixtures.js
@@ -32,6 +32,8 @@ export function createMockTable(overrides = {}) {
       where: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
       toArray: vi.fn().mockResolvedValue([]),
     }),
     search: vi.fn().mockReturnValue({
@@ -301,24 +303,4 @@ export function createMockUnifiedContext(overrides = {}) {
     prComments: overrides.prComments || [],
     customDocChunks: overrides.customDocChunks || [],
   };
-}
-
-// ============================================================================
-// Test Case Data Generators
-// ============================================================================
-
-/**
- * Generates test cases for shouldSkipPR function
- * @returns {{pr: PRData|null, oldest: string|null, newest: string|null, expected: boolean, description: string}[]} Array of test case objects
- */
-export function generateShouldSkipPRTestCases() {
-  return [
-    { pr: { merged_at: '2024-01-15' }, oldest: null, newest: null, expected: false, description: 'no date range provided' },
-    { pr: null, oldest: '2024-01-01', newest: '2024-01-31', expected: false, description: 'PR is null' },
-    { pr: { merged_at: '2024-01-15' }, oldest: '2024-01-01', newest: '2024-01-31', expected: true, description: 'PR within range' },
-    { pr: { merged_at: '2023-12-15' }, oldest: '2024-01-01', newest: '2024-01-31', expected: false, description: 'PR before range' },
-    { pr: { merged_at: '2024-02-15' }, oldest: '2024-01-01', newest: '2024-01-31', expected: false, description: 'PR after range' },
-    { pr: { created_at: '2024-01-15' }, oldest: '2024-01-01', newest: '2024-01-31', expected: true, description: 'using created_at' },
-    { pr: { updated_at: '2024-01-15' }, oldest: '2024-01-01', newest: '2024-01-31', expected: true, description: 'using updated_at' },
-  ];
 }

--- a/src/utils/pr-chunking.js
+++ b/src/utils/pr-chunking.js
@@ -1,6 +1,13 @@
 import chalk from 'chalk';
 import { verboseLog } from './logging.js';
 
+const CHARS_PER_ESTIMATED_TOKEN = 3;
+const FULL_CONTENT_CONTEXT_TOKEN_RATIO = 0.25;
+
+function estimateTokens(text) {
+  return Math.ceil((text?.length || 0) / CHARS_PER_ESTIMATED_TOKEN);
+}
+
 /**
  * Determines if a PR should be chunked based on estimated token usage
  * @param {Array} prFiles - Array of PR files with diffContent and content
@@ -14,12 +21,12 @@ export function shouldChunkPR(prFiles, options = {}) {
 
   // Calculate tokens for diff content
   const diffTokens = prFiles.reduce((sum, file) => {
-    return sum + Math.ceil((file.diffContent?.length || 0) / 3);
+    return sum + estimateTokens(file.diffContent);
   }, 0);
 
   // Calculate tokens for full file content (included in prompt for context awareness)
   const fullContentTokens = prFiles.reduce((sum, file) => {
-    return sum + Math.ceil((file.content?.length || 0) / 3);
+    return sum + estimateTokens(file.content);
   }, 0);
 
   // Total file-related tokens (both diff AND full content are sent)
@@ -64,13 +71,17 @@ export function shouldChunkPR(prFiles, options = {}) {
 export function chunkPRFiles(prFiles, maxTokensPerChunk = 35000) {
   // Calculate change complexity for each file (works for any language)
   // IMPORTANT: Token estimate must include BOTH diff AND full content since both are sent
-  const filesWithMetrics = prFiles.map((file) => ({
-    ...file,
-    changeSize: calculateChangeSize(file.diffContent),
-    fileComplexity: calculateFileComplexity(file),
-    // Estimate tokens for BOTH diff content AND full file content (both are included in prompt)
-    estimatedTokens: Math.ceil((file.diffContent?.length || 0) / 3) + Math.ceil((file.content?.length || 0) / 3),
-  }));
+  const filesWithMetrics = prFiles.flatMap((file) => {
+    const fileWithMetrics = {
+      ...file,
+      changeSize: calculateChangeSize(file.diffContent),
+      fileComplexity: calculateFileComplexity(file),
+      // Estimate tokens for BOTH diff content AND full file content (both are included in prompt)
+      estimatedTokens: estimateTokens(file.diffContent) + estimateTokens(file.content),
+    };
+
+    return splitOversizedFileForChunk(fileWithMetrics, maxTokensPerChunk);
+  });
 
   // Sort by directory + change importance for logical grouping
   const sortedFiles = filesWithMetrics.sort((a, b) => {
@@ -117,6 +128,178 @@ export function chunkPRFiles(prFiles, maxTokensPerChunk = 35000) {
   }
 
   return chunks;
+}
+
+function splitOversizedFileForChunk(file, maxTokensPerChunk) {
+  if (file.estimatedTokens <= maxTokensPerChunk) {
+    return [file];
+  }
+
+  const diffTokens = estimateTokens(file.diffContent);
+  if (diffTokens <= maxTokensPerChunk) {
+    return [capFileContentForChunk(file, maxTokensPerChunk, diffTokens)];
+  }
+
+  const contentBudget = Math.floor(maxTokensPerChunk * FULL_CONTENT_CONTEXT_TOKEN_RATIO);
+  const diffBudget = Math.max(maxTokensPerChunk - contentBudget, 1);
+  const diffParts = splitDiffToTokenBudget(file.diffContent, diffBudget);
+  const cappedContent = truncateToTokenBudget(file.content, contentBudget, 'file content');
+
+  return diffParts.map((diffPart, index) => ({
+    ...file,
+    diffContent: diffPart,
+    content: cappedContent,
+    estimatedTokens: estimateTokens(diffPart) + estimateTokens(cappedContent),
+    truncatedForChunk: cappedContent !== file.content,
+    diffSplitForChunk: true,
+    chunkPart: index + 1,
+    chunkParts: diffParts.length,
+    originalEstimatedTokens: file.estimatedTokens,
+    originalDiffEstimatedTokens: diffTokens,
+    summary: `${file.summary || pathBasename(file.filePath)} (diff part ${index + 1}/${diffParts.length})`,
+  }));
+}
+
+function capFileContentForChunk(file, maxTokensPerChunk, diffTokens) {
+  const contentBudget = Math.max(maxTokensPerChunk - diffTokens, 0);
+  const cappedContent = truncateToTokenBudget(file.content, contentBudget, 'file content');
+
+  return {
+    ...file,
+    content: cappedContent,
+    estimatedTokens: diffTokens + estimateTokens(cappedContent),
+    truncatedForChunk: cappedContent !== file.content,
+    originalEstimatedTokens: file.estimatedTokens,
+  };
+}
+
+function splitDiffToTokenBudget(diffContent, tokenBudget) {
+  if (!diffContent || estimateTokens(diffContent) <= tokenBudget) {
+    return [diffContent || ''];
+  }
+
+  const maxChars = tokenBudget * CHARS_PER_ESTIMATED_TOKEN;
+  const lines = diffContent.split('\n');
+  const firstHunkIndex = lines.findIndex((line) => line.startsWith('@@'));
+  const headerLines = firstHunkIndex > 0 ? lines.slice(0, firstHunkIndex) : [];
+  const bodyLines = firstHunkIndex >= 0 ? lines.slice(firstHunkIndex) : lines;
+  const headerText = headerLines.join('\n');
+  const units = splitDiffIntoUnits(bodyLines);
+  const parts = [];
+  let currentBody = '';
+
+  for (const unit of units) {
+    const candidateBody = currentBody ? `${currentBody}\n${unit}` : unit;
+    if (formatDiffPart(headerText, candidateBody, parts.length > 0).length <= maxChars) {
+      currentBody = candidateBody;
+      continue;
+    }
+
+    if (currentBody) {
+      parts.push(formatDiffPart(headerText, currentBody, parts.length > 0));
+      currentBody = '';
+    }
+
+    if (formatDiffPart(headerText, unit, parts.length > 0).length <= maxChars) {
+      currentBody = unit;
+      continue;
+    }
+
+    parts.push(...splitLargeDiffUnit(headerText, unit, maxChars, parts.length > 0));
+  }
+
+  if (currentBody) {
+    parts.push(formatDiffPart(headerText, currentBody, parts.length > 0));
+  }
+
+  return parts.length > 0 ? parts : [diffContent];
+}
+
+function splitDiffIntoUnits(lines) {
+  const hasHunks = lines.some((line) => line.startsWith('@@'));
+  if (!hasHunks) {
+    return [lines.join('\n')];
+  }
+
+  const units = [];
+  let currentUnit = [];
+
+  for (const line of lines) {
+    if (line.startsWith('@@') && currentUnit.length > 0) {
+      units.push(currentUnit.join('\n'));
+      currentUnit = [];
+    }
+    currentUnit.push(line);
+  }
+
+  if (currentUnit.length > 0) {
+    units.push(currentUnit.join('\n'));
+  }
+
+  return units;
+}
+
+function splitLargeDiffUnit(headerText, unit, maxChars, hasPreviousPart) {
+  const parts = [];
+
+  for (let offset = 0; offset < unit.length; ) {
+    const prefix = buildBoundedDiffPrefix(headerText, hasPreviousPart || parts.length > 0, maxChars);
+    const sliceChars = Math.max(maxChars - prefix.length, 1);
+    const slice = unit.slice(offset, offset + sliceChars);
+    parts.push(`${prefix}${slice}`);
+    offset += sliceChars;
+  }
+
+  return parts;
+}
+
+function buildBoundedDiffPrefix(headerText, isContinuation, maxChars) {
+  const prefixText = [headerText, isContinuation ? splitMarker() : ''].filter(Boolean).join('\n');
+  if (!prefixText || maxChars <= 1) {
+    return '';
+  }
+
+  const maxPrefixChars = Math.max(maxChars - 2, 0);
+  const boundedPrefix = prefixText.length > maxPrefixChars ? prefixText.slice(0, maxPrefixChars) : prefixText;
+  return boundedPrefix ? `${boundedPrefix}\n` : '';
+}
+
+function formatDiffPart(headerText, bodyText, isContinuation) {
+  return [headerText, isContinuation ? splitMarker() : '', bodyText].filter(Boolean).join('\n');
+}
+
+function splitMarker() {
+  return '... (diff split for PR review token budget; continued from another part) ...';
+}
+
+function pathBasename(filePath) {
+  return (
+    String(filePath || '')
+      .split('/')
+      .pop() || 'file'
+  );
+}
+
+function truncateToTokenBudget(text, tokenBudget, label) {
+  if (!text || tokenBudget <= 0) {
+    return '';
+  }
+
+  const maxChars = tokenBudget * CHARS_PER_ESTIMATED_TOKEN;
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  const marker = `\n... (${label} truncated for PR review token budget; original length ${text.length} characters) ...\n`;
+  if (maxChars <= marker.length + 20) {
+    return text.slice(0, Math.max(maxChars, 0));
+  }
+
+  const availableChars = maxChars - marker.length;
+  const headChars = Math.ceil(availableChars * 0.7);
+  const tailChars = Math.max(availableChars - headChars, 0);
+
+  return `${text.slice(0, headChars)}${marker}${tailChars > 0 ? text.slice(-tailChars) : ''}`;
 }
 
 /**
@@ -201,25 +384,25 @@ export function combineChunkResults(chunkResults, totalFiles, options = {}) {
     },
   };
 
-  // Combine file-specific results
+  const mergedResultsByFile = new Map();
+
+  // Combine file-specific results, merging split-file review parts back into one file result.
   chunkResults.forEach((chunkResult, chunkIndex) => {
     if (chunkResult.success && chunkResult.results) {
-      chunkResult.results.forEach((fileResult) => {
-        // Add chunk context to each result
-        const enhancedResult = {
-          ...fileResult,
-          chunkInfo: {
-            chunkNumber: chunkIndex + 1,
-            totalChunks: chunkResults.length,
-          },
-        };
-        combinedResult.results.push(enhancedResult);
+      chunkResult.results.forEach((fileResult, resultIndex) => {
+        mergeChunkFileResult(mergedResultsByFile, fileResult, {
+          chunkNumber: chunkIndex + 1,
+          totalChunks: chunkResults.length,
+          resultIndex,
+        });
       });
     }
   });
 
+  combinedResult.results = Array.from(mergedResultsByFile.values());
+
   // Create combined summary
-  combinedResult.combinedSummary = createCombinedSummary(chunkResults);
+  combinedResult.combinedSummary = createCombinedSummary(combinedResult.results, chunkResults);
 
   // Detect and merge cross-chunk issues
   combinedResult.crossChunkIssues = detectCrossChunkIssues(chunkResults);
@@ -229,22 +412,80 @@ export function combineChunkResults(chunkResults, totalFiles, options = {}) {
   return combinedResult;
 }
 
+function mergeChunkFileResult(mergedResultsByFile, fileResult, chunkInfo) {
+  const key = fileResult.filePath || `chunk-${chunkInfo.chunkNumber}-result-${chunkInfo.resultIndex}`;
+  const resultWithChunkInfo = {
+    ...fileResult,
+    chunkInfo: {
+      chunkNumber: chunkInfo.chunkNumber,
+      totalChunks: chunkInfo.totalChunks,
+    },
+    chunkInfos: [
+      {
+        chunkNumber: chunkInfo.chunkNumber,
+        totalChunks: chunkInfo.totalChunks,
+      },
+    ],
+  };
+
+  if (!mergedResultsByFile.has(key)) {
+    mergedResultsByFile.set(key, resultWithChunkInfo);
+    return;
+  }
+
+  const existing = mergedResultsByFile.get(key);
+  const existingIssues = existing.results?.issues || [];
+  const newIssues = fileResult.results?.issues || [];
+  existing.results = {
+    ...existing.results,
+    ...fileResult.results,
+    issues: mergeIssues(existingIssues, newIssues),
+  };
+  existing.chunkInfos.push({
+    chunkNumber: chunkInfo.chunkNumber,
+    totalChunks: chunkInfo.totalChunks,
+  });
+  existing.chunkInfo = {
+    chunkNumber: existing.chunkInfo.chunkNumber,
+    totalChunks: chunkInfo.totalChunks,
+    chunkNumbers: [...new Set(existing.chunkInfos.map((info) => info.chunkNumber))],
+  };
+}
+
+function mergeIssues(existingIssues, newIssues) {
+  const mergedIssues = [...existingIssues];
+  const seenIssueKeys = new Set(existingIssues.map(issueKey));
+
+  for (const issue of newIssues) {
+    const key = issueKey(issue);
+    if (!seenIssueKeys.has(key)) {
+      mergedIssues.push(issue);
+      seenIssueKeys.add(key);
+    }
+  }
+
+  return mergedIssues;
+}
+
+function issueKey(issue) {
+  return JSON.stringify({
+    type: issue.type,
+    severity: issue.severity,
+    description: issue.description,
+    suggestion: issue.suggestion,
+    lineNumbers: issue.lineNumbers,
+    codeSuggestion: issue.codeSuggestion,
+  });
+}
+
 /**
  * Creates a summary from combined chunk results
  * @param {Array} chunkResults - Array of chunk review results
  * @returns {string} Combined summary text
  */
-function createCombinedSummary(chunkResults) {
-  const totalIssues = chunkResults.reduce((sum, chunk) => {
-    if (!chunk.results) {
-      return sum;
-    }
-    return (
-      sum +
-      chunk.results.reduce((fileSum, file) => {
-        return fileSum + (file.results?.issues?.length || 0);
-      }, 0)
-    );
+function createCombinedSummary(results, chunkResults) {
+  const totalIssues = results.reduce((sum, file) => {
+    return sum + (file.results?.issues?.length || 0);
   }, 0);
 
   const successfulChunks = chunkResults.filter((c) => c.success).length;
@@ -285,7 +526,8 @@ function detectCrossChunkIssues(chunkResults) {
   // Identify patterns that appear across multiple chunks
   issueGroups.forEach((issues) => {
     const uniqueChunks = new Set(issues.map((i) => i.chunkId));
-    if (uniqueChunks.size > 1) {
+    const uniqueFiles = new Set(issues.map((i) => i.filePath));
+    if (uniqueChunks.size > 1 && uniqueFiles.size > 1) {
       crossChunkIssues.push({
         type: 'pattern',
         severity: 'medium',

--- a/src/utils/pr-chunking.test.js
+++ b/src/utils/pr-chunking.test.js
@@ -163,12 +163,39 @@ describe('chunkPRFiles', () => {
       expect(chunks[0].files[0].estimatedTokens).toBe(0);
     });
 
-    it('should handle single large file that exceeds chunk limit', () => {
-      const prFiles = [{ filePath: 'src/huge.js', diffContent: 'x'.repeat(150000), content: 'y'.repeat(150000) }];
+    it('should split a single large file without dropping changed hunks', () => {
+      const hugeDiff = [
+        'diff --git a/src/huge.js b/src/huge.js',
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        ...Array.from({ length: 90 }, (_, i) => `@@ -${i},1 +${i},1 @@\n-context ${i}\n+changed sentinel-${i} ${'x'.repeat(5000)}`),
+      ].join('\n');
+      const prFiles = [{ filePath: 'src/huge.js', diffContent: hugeDiff, content: 'y'.repeat(150000) }];
       const chunks = chunkPRFiles(prFiles, 35000);
-      // Single file should still be in its own chunk even if it exceeds limit
-      expect(chunks.length).toBe(1);
-      expect(chunks[0].files.length).toBe(1);
+      const splitFiles = chunks.flatMap((chunk) => chunk.files);
+      const combinedDiff = splitFiles.map((file) => file.diffContent).join('\n');
+
+      expect(splitFiles.length).toBeGreaterThan(1);
+      expect(splitFiles.every((file) => file.diffSplitForChunk)).toBe(true);
+      expect(splitFiles.every((file) => file.originalEstimatedTokens > 35000)).toBe(true);
+      expect(chunks.every((chunk) => chunk.totalTokens <= 35000)).toBe(true);
+      expect(combinedDiff).toContain('changed sentinel-0');
+      expect(combinedDiff).toContain('changed sentinel-45');
+      expect(combinedDiff).toContain('changed sentinel-89');
+    });
+
+    it('should keep split diff parts within budget for tiny budgets with large headers', () => {
+      const hugeDiff = [
+        `diff --git a/${'very-long-path/'.repeat(20)}huge.js b/${'very-long-path/'.repeat(20)}huge.js`,
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        `@@ -1,1 +1,1 @@\n-old\n+${'x'.repeat(120)}`,
+      ].join('\n');
+
+      const chunks = chunkPRFiles([{ filePath: 'src/huge.js', diffContent: hugeDiff, content: 'y'.repeat(120) }], 5);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.every((chunk) => chunk.totalTokens <= 5)).toBe(true);
     });
   });
 });
@@ -218,6 +245,33 @@ describe('combineChunkResults', () => {
       expect(combined.prContext.totalFiles).toBe(5);
       expect(combined.prContext.chunkedReview).toBe(true);
       expect(combined.prContext.chunks).toBe(1);
+    });
+
+    it('should merge duplicate file results from split diff chunks', () => {
+      const duplicateIssue = { type: 'bug', description: 'Missing null check', lineNumbers: [10], suggestion: 'Add a guard' };
+      const chunkResults = [
+        {
+          success: true,
+          results: [{ filePath: 'src/huge.js', results: { issues: [duplicateIssue] } }],
+        },
+        {
+          success: true,
+          results: [
+            {
+              filePath: 'src/huge.js',
+              results: { issues: [duplicateIssue, { type: 'bug', description: 'Handle timeout', lineNumbers: [50] }] },
+            },
+          ],
+        },
+      ];
+
+      const combined = combineChunkResults(chunkResults, 1);
+
+      expect(combined.results.length).toBe(1);
+      expect(combined.results[0].filePath).toBe('src/huge.js');
+      expect(combined.results[0].results.issues).toHaveLength(2);
+      expect(combined.results[0].chunkInfo.chunkNumbers).toEqual([1, 2]);
+      expect(combined.combinedSummary).toContain('Total issues found: 2');
     });
   });
 
@@ -307,6 +361,25 @@ describe('combineChunkResults', () => {
         },
       ];
       const combined = combineChunkResults(chunkResults, 2);
+      expect(combined.crossChunkIssues.length).toBe(0);
+    });
+
+    it('should not flag duplicate split-file issues as cross-chunk patterns', () => {
+      const chunkResults = [
+        {
+          chunkId: 1,
+          success: true,
+          results: [{ filePath: 'src/huge.js', results: { issues: [{ type: 'bug', description: 'Missing null check in handler' }] } }],
+        },
+        {
+          chunkId: 2,
+          success: true,
+          results: [{ filePath: 'src/huge.js', results: { issues: [{ type: 'bug', description: 'Missing null check in handler' }] } }],
+        },
+      ];
+
+      const combined = combineChunkResults(chunkResults, 1);
+
       expect(combined.crossChunkIssues.length).toBe(0);
     });
   });


### PR DESCRIPTION
The following issues have been fixed in this PR:

- Keeps oversized PR review chunks within budget and merges split-file results back by file path, so one large file does not produce duplicate findings or false cross-chunk patterns.
- Tracks PR update timestamps during PR-history sync, while keeping a legacy-safe skip fallback to avoid a one-time mass re-crawl.
- Ensures PR-history-only commands initialize the PR comments schema before opening the table, so the nullable `pr_updated_at` column is added automatically for existing LanceDB tables.
- Pages PR sync-state reads with stable ordering and a narrow projection so large comment tables do not miss rows or deserialize embedding vectors unnecessarily.
- Removes stale deleted PR comments using live comment IDs fetched from GitHub, without deleting comments that were still live but skipped locally because validation or embedding generation failed.
- Hashes raw file content for embedding freshness instead of transformed chunk content.
- Preserves custom documentation fallback context when direct RAG matches are missing.