### PR TITLE
Relax Node engine minimum

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -18,7 +18,7 @@ CodeCritique is an AI-powered code review tool that:
 
 ## Tech Stack
 
-- **Runtime**: Node.js >= 24.15.0
+- **Runtime**: Node.js >= 24
 - **Language**: JavaScript (ES modules)
 - **Testing**: Vitest
 - **Storage**: LanceDB (vectors)

--- a/.roo/rules/01-project-rules.md
+++ b/.roo/rules/01-project-rules.md
@@ -10,7 +10,7 @@ For comprehensive guidelines, see **AGENTS.md** in the project root.
 
 - **Type**: CLI Tool (AI-powered code review)
 - **Language**: JavaScript with ES modules
-- **Runtime**: Node.js >= 24.15.0
+- **Runtime**: Node.js >= 24
 - **Testing**: Vitest with global test APIs
 
 ## Essential Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This document provides comprehensive guidance for AI coding agents working on th
 
 ### Tech Stack
 
-- **Runtime**: Node.js >= 24.15.0
+- **Runtime**: Node.js >= 24
 - **Language**: JavaScript (ES modules)
 - **Testing**: Vitest with coverage
 - **Linting**: ESLint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ CodeCritique is an AI-powered code review tool that:
 
 ## Tech Stack
 
-- **Runtime**: Node.js >= 24.15.0
+- **Runtime**: Node.js >= 24
 - **Language**: JavaScript (ES modules)
 - **Testing**: Vitest
 - **Storage**: LanceDB (vectors)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,9 @@ Thank you for your interest in contributing to CodeCritique! This document provi
 
 ### Prerequisites
 
-- Node.js >= 24.15.0
-- npm >= 11.12.1
+- Node.js 24 or newer
+- npm 11 or newer
+- Maintainer tooling is pinned with Volta to Node.js 24.15.0 and npm 11.12.1.
 - Git (for diff-based analysis)
 - Anthropic API key (for LLM analysis features)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/codecritique.svg)](https://www.npmjs.com/package/codecritique)
 [![npm downloads](https://img.shields.io/npm/dm/codecritique.svg)](https://www.npmjs.com/package/codecritique)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D24.15.0-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D24-brightgreen.svg)](https://nodejs.org/)
 [![CI](https://github.com/cosmocoder/CodeCritique/actions/workflows/release.yml/badge.svg)](https://github.com/cosmocoder/CodeCritique/actions/workflows/release.yml)
 
 **AI-Powered Code Review. Context-Aware. Privacy-First.**
@@ -96,7 +96,7 @@ This RAG-based approach provides more accurate, project-specific code reviews co
 
 ### Prerequisites
 
-- **Node.js** v24.15.0 or higher
+- **Node.js** 24 or newer
 - **Git** (for diff-based analysis)
 - **Anthropic API key** (for LLM analysis)
 
@@ -199,7 +199,7 @@ For easier integration with non-JavaScript projects, you can use the provided sh
 
 3. **Environment setup** (the script handles this automatically):
    - Creates/uses `.env` file in your project directory
-   - Validates Node.js v24.15.0+ requirement
+   - Validates Node.js 24+ requirement
    - Provides helpful error messages for missing dependencies
 
 ## Quick Start

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
         "vitest": "4.1.8"
       },
       "engines": {
-        "node": ">=24.15.0",
-        "npm": ">=11.12.1 <12"
+        "node": ">=24",
+        "npm": ">=11"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "npm": "11.12.1"
   },
   "engines": {
-    "node": ">=24.15.0",
-    "npm": ">=11.12.1 <12"
+    "node": ">=24",
+    "npm": ">=11"
   },
   "engine-strict": true,
   "publishConfig": {

--- a/src/codecritique.sh
+++ b/src/codecritique.sh
@@ -6,7 +6,7 @@
 # Check if Node.js is installed
 if ! command -v node &> /dev/null; then
     echo "Error: Node.js is required but not installed."
-    echo "Please install Node.js v24.15.0 or higher: https://nodejs.org/"
+    echo "Please install Node.js 24 or newer: https://nodejs.org/"
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

The Node 24 migration pinned the maintainer runtime with Volta, but it also made the published package engines require Node.js 24.15.0 or newer. That made the exact maintainer patch version a consumer requirement.

## Fix

Relax the consumer-facing package engines to require Node.js 24 or newer and npm 11 or newer, while keeping Volta pinned to Node.js 24.15.0 and npm 11.12.1 for maintainers.

Update README, wrapper, contributing docs, and agent guidance so they describe the supported runtime as Node 24+ instead of Node 24.15.0+.