### PR TITLE
Surface holistic PR findings

### DIFF
--- a/.github/actions/pr-review/post-comments.js
+++ b/.github/actions/pr-review/post-comments.js
@@ -7,6 +7,44 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { shouldSkipSimilarIssue, loadFeedbackData } from '../../../src/feedback-loader.js';
 
+function formatPRLevelFindings(prLevelFindings = {}) {
+  const summary = prLevelFindings.summary || '';
+  const issues = Array.isArray(prLevelFindings.issues) ? prLevelFindings.issues : [];
+  const recommendations = Array.isArray(prLevelFindings.recommendations) ? prLevelFindings.recommendations : [];
+
+  if (!summary && issues.length === 0 && recommendations.length === 0) {
+    return '';
+  }
+
+  const lines = ['### 🔎 PR-level findings', ''];
+
+  if (summary) {
+    lines.push(summary, '');
+  }
+
+  for (const [index, issue] of issues.entries()) {
+    const severity = issue.severity || 'info';
+    lines.push(`**${index + 1}. [${severity}] ${issue.description}**`);
+    if (issue.files?.length > 0) {
+      lines.push(`- Affected files: ${issue.files.join(', ')}`);
+    }
+    if (issue.suggestion) {
+      lines.push(`- Suggestion: ${issue.suggestion}`);
+    }
+    lines.push('');
+  }
+
+  if (recommendations.length > 0) {
+    lines.push('**Recommendations:**');
+    for (const recommendation of recommendations) {
+      lines.push(`- ${recommendation}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
+}
+
 /**
  * Main function for posting CodeCritique review comments to GitHub Pull Requests.
  *
@@ -284,6 +322,8 @@ export default async ({ github, context, core }) => {
     console.log('✅ JSON file is valid');
 
     const totalIssues = reviewData.summary?.totalIssues || 0;
+    const prLevelFindingsSection = formatPRLevelFindings(reviewData.prLevelFindings);
+    const hasReviewFindings = totalIssues > 0 || Boolean(prLevelFindingsSection);
 
     console.log(`📊 Parsing results: ${totalIssues} issues found`);
 
@@ -403,15 +443,16 @@ export default async ({ github, context, core }) => {
 **Issues Found:** ${totalIssues}
 
 ${
-  totalIssues > 0
+  hasReviewFindings
     ? `### 📋 Review Results
 
-The AI has identified potential improvements in your code. Please review the inline comments for detailed feedback.`
+The AI has identified review findings or recommendations. PR-level findings are listed below when available, and file-specific findings may appear as inline comments.`
     : `### ✅ No Issues Found
 
 Great job! The AI review didn't identify any significant issues with your changes.`
 }
 
+${prLevelFindingsSection ? `${prLevelFindingsSection}\n\n` : ''}
 *Review was enhanced with codebase context using cached embeddings.*
 
 ${uniqueCommentId}`;

--- a/.github/actions/pr-review/post-comments.test.js
+++ b/.github/actions/pr-review/post-comments.test.js
@@ -781,6 +781,62 @@ describe('post-comments.js', () => {
     });
   });
 
+  describe('PR-level findings', () => {
+    it('should include PR-level findings in the summary comment without posting inline comments', async () => {
+      const prLevelOnlyIssue = {
+        summary: { totalFilesReviewed: 2, totalIssues: 1, fileLevelIssues: 0, prLevelIssues: 1 },
+        prLevelFindings: {
+          summary: 'The PR updates a shared state flow across multiple files.',
+          issues: [
+            {
+              description: 'State updates are inconsistent across files',
+              severity: 'high',
+              files: ['src/a.js', 'src/b.js'],
+              suggestion: 'Use the shared state updater in both files.',
+            },
+          ],
+          recommendations: ['Add a regression test for the shared flow'],
+        },
+        details: [],
+      };
+
+      fs.readFileSync.mockReturnValue(JSON.stringify(prLevelOnlyIssue));
+
+      await postComments({ github: mockGithub, context: mockContext, core: mockCore });
+
+      const createCommentCall = mockGithub.rest.issues.createComment.mock.calls[0][0];
+      expect(createCommentCall.body).toContain('PR-level findings');
+      expect(createCommentCall.body).toContain('The PR updates a shared state flow across multiple files.');
+      expect(createCommentCall.body).toContain('State updates are inconsistent across files');
+      expect(createCommentCall.body).toContain('Affected files: src/a.js, src/b.js');
+      expect(createCommentCall.body).toContain('Add a regression test for the shared flow');
+      expect(mockGithub.rest.pulls.createReviewComment).not.toHaveBeenCalled();
+    });
+
+    it('should avoid the no-issues message when PR-level notes have no counted issues', async () => {
+      const prLevelNotesOnly = {
+        summary: { totalFilesReviewed: 2, totalIssues: 0, fileLevelIssues: 0, prLevelIssues: 0 },
+        prLevelFindings: {
+          summary: 'The PR changes an integration flow that depends on shared state.',
+          issues: [],
+          recommendations: ['Add a regression test for the shared flow'],
+        },
+        details: [],
+      };
+
+      fs.readFileSync.mockReturnValue(JSON.stringify(prLevelNotesOnly));
+
+      await postComments({ github: mockGithub, context: mockContext, core: mockCore });
+
+      const createCommentCall = mockGithub.rest.issues.createComment.mock.calls[0][0];
+      expect(createCommentCall.body).toContain('Review Results');
+      expect(createCommentCall.body).not.toContain('No Issues Found');
+      expect(createCommentCall.body).toContain('The PR changes an integration flow that depends on shared state.');
+      expect(createCommentCall.body).toContain('Add a regression test for the shared flow');
+      expect(mockGithub.rest.pulls.createReviewComment).not.toHaveBeenCalled();
+    });
+  });
+
   describe('path conversion edge cases', () => {
     it('should handle paths without runner prefix', async () => {
       const simplePathIssue = {

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import { reviewFile, reviewFiles, reviewPullRequest } from './rag-review.js';
 import { execGitSafe } from './utils/command.js';
 import { ensureBranchExists, findBaseBranch } from './utils/git.js';
 import { verboseLog } from './utils/logging.js';
+import { collectPRLevelFindings, getFileLevelIssueCount, hasPRLevelFindings } from './utils/review-results.js';
 
 // Create a default embeddings system instance
 const embeddingsSystem = getDefaultEmbeddingsSystem();
@@ -424,7 +425,7 @@ async function runCodeReview(options) {
         // Determine output function based on format option
         const outputFn = options.output === 'json' ? outputJson : options.output === 'markdown' ? outputMarkdown : outputText;
         // Pass the detailed results array to the output function
-        outputFn(reviewResult.results, options);
+        outputFn(reviewResult.results, options, reviewResult);
         console.log(chalk.bold.green(`\nAnalysis complete for ${operationDescription}! (${duration}s)`));
       }
       else {
@@ -435,7 +436,7 @@ async function runCodeReview(options) {
         // Still output empty results if outputFile is specified (for CI/CD pipelines)
         if (options.outputFile) {
           const outputFn = options.output === 'json' ? outputJson : options.output === 'markdown' ? outputMarkdown : outputText;
-          outputFn([], options);
+          outputFn([], options, reviewResult);
           console.log(chalk.yellow(`Empty results written to: ${options.outputFile}`));
         }
 
@@ -1013,14 +1014,20 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
  *
  * @param {Array<Object>} reviewResults - Array of individual file review results
  * @param {Object} options - Command line options
+ * @param {Object} aggregateResult - Full review result with PR-level context
  */
-function outputJson(reviewResults, options) {
+function outputJson(reviewResults, options, aggregateResult = {}) {
+  const prLevelFindings = collectPRLevelFindings(reviewResults, aggregateResult);
+  const fileLevelIssues = getFileLevelIssueCount(reviewResults);
+
   // Structure the output to be informative
   const output = {
     summary: {
       totalFilesReviewed: reviewResults.length,
       filesWithIssues: reviewResults.filter((r) => r.success && !r.skipped && r.results?.issues?.length > 0).length,
-      totalIssues: reviewResults.reduce((sum, r) => sum + (r.results?.issues?.length || 0), 0),
+      totalIssues: fileLevelIssues + prLevelFindings.issues.length,
+      fileLevelIssues,
+      prLevelIssues: prLevelFindings.issues.length,
       issuesWithCodeSuggestions: reviewResults.reduce((sum, r) => {
         if (!r.success || r.skipped || !r.results?.issues) {
           return sum;
@@ -1049,6 +1056,10 @@ function outputJson(reviewResults, options) {
     }),
   };
 
+  if (hasPRLevelFindings(prLevelFindings)) {
+    output.prLevelFindings = prLevelFindings;
+  }
+
   const jsonOutput = JSON.stringify(output, null, 2);
 
   // If output-file is specified, write to file instead of stdout
@@ -1067,13 +1078,15 @@ function outputJson(reviewResults, options) {
  *
  * @param {Array<Object>} reviewResults - Array of individual file review results
  * @param {Object} options - Command line options
+ * @param {Object} aggregateResult - Full review result with PR-level context
  */
-function outputMarkdown(reviewResults, options) {
+function outputMarkdown(reviewResults, options, aggregateResult = {}) {
   const totalFiles = reviewResults.length;
   const filesWithIssues = reviewResults.filter((r) => r.success && !r.skipped && r.results?.issues?.length > 0).length;
-  const totalIssues = reviewResults.reduce((sum, r) => sum + (r.results?.issues?.length || 0), 0);
   const skippedFiles = reviewResults.filter((r) => r.skipped).length;
   const errorFiles = reviewResults.filter((r) => !r.success).length;
+  const prLevelFindings = collectPRLevelFindings(reviewResults, aggregateResult);
+  const totalIssues = getFileLevelIssueCount(reviewResults) + prLevelFindings.issues.length;
 
   const lines = [
     '# AI Code Review Results (RAG Approach)',
@@ -1091,6 +1104,8 @@ function outputMarkdown(reviewResults, options) {
   if (errorFiles > 0) {
     lines.push(`- **Errors:** ${errorFiles}`);
   }
+
+  appendPRLevelFindingsMarkdown(lines, prLevelFindings);
 
   lines.push('', '## Detailed Review per File', '');
 
@@ -1157,13 +1172,15 @@ function outputMarkdown(reviewResults, options) {
  *
  * @param {Array<Object>} reviewResults - Array of individual file review results
  * @param {Object} cliOptions - Command line options
+ * @param {Object} aggregateResult - Full review result with PR-level context
  */
-function outputText(reviewResults, cliOptions) {
+function outputText(reviewResults, cliOptions, aggregateResult = {}) {
   const totalFiles = reviewResults.length;
   const filesWithIssues = reviewResults.filter((r) => r.success && !r.skipped && r.results?.issues?.length > 0).length;
-  const totalIssues = reviewResults.reduce((sum, r) => sum + (r.results?.issues?.length || 0), 0);
   const skippedFiles = reviewResults.filter((r) => r.skipped).length;
   const errorFiles = reviewResults.filter((r) => !r.success).length;
+  const prLevelFindings = collectPRLevelFindings(reviewResults, aggregateResult);
+  const totalIssues = getFileLevelIssueCount(reviewResults) + prLevelFindings.issues.length;
 
   console.log(chalk.bold.blue('\n===== AI Code Review Summary ====='));
   console.log(`Files Analyzed: ${chalk.bold(totalFiles)}`);
@@ -1176,6 +1193,8 @@ function outputText(reviewResults, cliOptions) {
     console.log(`Errors: ${chalk.red(errorFiles)}`);
   }
   console.log(chalk.bold.blue('================================================'));
+
+  outputPRLevelFindingsText(prLevelFindings);
 
   reviewResults.forEach((fileResult) => {
     if (!fileResult.success) {
@@ -1228,6 +1247,68 @@ function outputText(reviewResults, cliOptions) {
 
     console.log(chalk.gray(`========================================${'='.repeat(fileResult.filePath.length)}`));
   });
+}
+
+function appendPRLevelFindingsMarkdown(lines, prLevelFindings) {
+  if (!hasPRLevelFindings(prLevelFindings)) {
+    return;
+  }
+
+  lines.push('', '## PR-Level Findings', '');
+
+  if (prLevelFindings.summary) {
+    lines.push(`**Summary:** ${prLevelFindings.summary}`, '');
+  }
+
+  for (const issue of prLevelFindings.issues) {
+    const severity = issue.severity || 'info';
+    const severityEmoji = getSeverityEmoji(severity);
+    lines.push(`- **[${severity.toUpperCase()}] ${severityEmoji}** ${issue.description}`);
+    if (issue.files?.length > 0) {
+      lines.push(`  - Affected files: ${issue.files.join(', ')}`);
+    }
+    if (issue.suggestion) {
+      lines.push(`  - Suggestion: ${issue.suggestion}`);
+    }
+  }
+
+  if (prLevelFindings.recommendations.length > 0) {
+    lines.push('', '**Recommendations:**', '');
+    for (const recommendation of prLevelFindings.recommendations) {
+      lines.push(`- ${recommendation}`);
+    }
+  }
+}
+
+function outputPRLevelFindingsText(prLevelFindings) {
+  if (!hasPRLevelFindings(prLevelFindings)) {
+    return;
+  }
+
+  console.log(chalk.bold.underline('\n===== PR-Level Findings ====='));
+  if (prLevelFindings.summary) {
+    console.log(chalk.bold.cyan(`Summary: ${prLevelFindings.summary}`));
+  }
+
+  for (const issue of prLevelFindings.issues) {
+    const severity = issue.severity || 'info';
+    const severityColor = getSeverityColor(severity);
+    console.log(`  ${severityColor(`[${severity.toUpperCase()}]`)} ${issue.description}`);
+    if (issue.files?.length > 0) {
+      console.log(`    Affected files: ${issue.files.join(', ')}`);
+    }
+    if (issue.suggestion) {
+      console.log(`    ${chalk.green(`Suggestion: ${issue.suggestion}`)}`);
+    }
+    console.log('');
+  }
+
+  if (prLevelFindings.recommendations.length > 0) {
+    console.log(chalk.bold.yellow('Recommendations:'));
+    for (const recommendation of prLevelFindings.recommendations) {
+      console.log(`  - ${recommendation}`);
+    }
+  }
 }
 
 // --- Severity Helpers (Remain Unchanged) --- //

--- a/src/utils/review-results.js
+++ b/src/utils/review-results.js
@@ -1,0 +1,125 @@
+/**
+ * Helpers for summarizing review results across file-level and PR-level findings.
+ */
+
+export function getFileLevelIssueCount(reviewResults = []) {
+  return reviewResults.reduce((sum, result) => sum + (result?.results?.issues?.length || 0), 0);
+}
+
+export function hasPRLevelFindings(prLevelFindings = {}) {
+  return Boolean(prLevelFindings.summary || prLevelFindings.issues?.length || prLevelFindings.recommendations?.length);
+}
+
+export function collectPRLevelFindings(reviewResults = [], aggregateResult = {}) {
+  const findings = {
+    summary: null,
+    issues: [],
+    recommendations: [],
+  };
+  const seenIssues = new Set();
+  const seenRecommendations = new Set();
+
+  const addRecommendation = (recommendation) => {
+    if (!recommendation) {
+      return;
+    }
+
+    const text = normalizeRecommendation(recommendation);
+    if (!seenRecommendations.has(text)) {
+      findings.recommendations.push(text);
+      seenRecommendations.add(text);
+    }
+  };
+
+  const addIssue = (issue, source) => {
+    const normalized = normalizePRLevelIssue(issue, source);
+    if (!normalized.description) {
+      return;
+    }
+
+    const key = JSON.stringify({
+      type: normalized.type,
+      severity: normalized.severity,
+      description: normalized.description,
+      files: [...normalized.files].sort(),
+      suggestion: normalized.suggestion,
+    });
+    if (seenIssues.has(key)) {
+      return;
+    }
+
+    findings.issues.push(normalized);
+    seenIssues.add(key);
+  };
+
+  const addHolisticAnalysis = (analysis) => {
+    const results = analysis?.results || analysis;
+    if (!results) {
+      return;
+    }
+
+    findings.summary ||= results.overallSummary || results.summary || null;
+
+    for (const issue of results.crossFileIssues || []) {
+      addIssue(issue, 'cross-file');
+    }
+    for (const recommendation of results.recommendations || []) {
+      addRecommendation(recommendation);
+    }
+  };
+
+  addHolisticAnalysis(aggregateResult?.prContext?.holisticAnalysis);
+  addHolisticAnalysis(aggregateResult?.holisticAnalysis);
+
+  for (const issue of aggregateResult?.crossChunkIssues || []) {
+    addRecommendation(normalizeCrossChunkPattern(issue));
+  }
+
+  for (const result of reviewResults) {
+    addHolisticAnalysis(result?.holisticAnalysis);
+  }
+
+  return findings;
+}
+
+function normalizePRLevelIssue(issue = {}, source) {
+  const files = issue.files || issue.affectedFiles || issue.filePaths || [];
+  const fileList = Array.isArray(files) ? files : [files];
+
+  return {
+    type: issue.type || source,
+    source,
+    severity: issue.severity || 'info',
+    description: issue.description || issue.message || '',
+    suggestion: issue.suggestion || issue.recommendation || '',
+    files: fileList.filter(Boolean),
+    lineNumbers: issue.lineNumbers || [],
+  };
+}
+
+function normalizeRecommendation(recommendation) {
+  if (typeof recommendation === 'string') {
+    return recommendation;
+  }
+
+  if (typeof recommendation === 'object') {
+    const parts = [recommendation.category, recommendation.suggestion, recommendation.impact].filter(Boolean);
+    return parts.join(': ') || JSON.stringify(recommendation);
+  }
+
+  return String(recommendation);
+}
+
+function normalizeCrossChunkPattern(issue = {}) {
+  const description = issue.description || issue.message;
+  const suggestion = issue.suggestion || issue.recommendation;
+  const files = issue.affectedFiles || issue.files || [];
+  const fileList = Array.isArray(files) ? files.filter(Boolean) : [files].filter(Boolean);
+  const parts = [description, suggestion].filter(Boolean);
+
+  if (fileList.length > 0) {
+    parts.push(`Affected files: ${fileList.join(', ')}`);
+  }
+
+  return parts.join(' ');
+}

--- a/src/utils/review-results.test.js
+++ b/src/utils/review-results.test.js
@@ -1,0 +1,84 @@
+import { collectPRLevelFindings, getFileLevelIssueCount, hasPRLevelFindings } from './review-results.js';
+
+describe('review-results utilities', () => {
+  it('does not count synthetic cross-chunk patterns as additional issues', () => {
+    const reviewResults = [
+      { results: { issues: [{ description: 'File issue' }] } },
+      { results: { issues: [{ description: 'Another file issue' }] } },
+    ];
+    const aggregateResult = {
+      crossChunkIssues: [{ description: 'Pattern issue', severity: 'medium', affectedFiles: ['a.js', 'b.js'] }],
+    };
+
+    const findings = collectPRLevelFindings(reviewResults, aggregateResult);
+
+    expect(getFileLevelIssueCount(reviewResults)).toBe(2);
+    expect(getFileLevelIssueCount(reviewResults) + findings.issues.length).toBe(2);
+    expect(findings.recommendations).toEqual(['Pattern issue Affected files: a.js, b.js']);
+  });
+
+  it('collects and deduplicates holistic cross-file findings from aggregate and file results', () => {
+    const crossFileIssue = {
+      message: 'State update is inconsistent across files',
+      severity: 'high',
+      files: ['src/a.js', 'src/unchanged-shared-state.js'],
+      suggestion: 'Use the shared state updater in both files.',
+    };
+    const reviewResults = [
+      {
+        holisticAnalysis: {
+          overallSummary: 'Holistic summary',
+          crossFileIssues: [crossFileIssue],
+          recommendations: [],
+        },
+      },
+    ];
+    const aggregateResult = {
+      prContext: {
+        holisticAnalysis: {
+          results: {
+            summary: 'Aggregate summary',
+            crossFileIssues: [crossFileIssue],
+            recommendations: [{ category: 'testing', suggestion: 'Add an integration test' }],
+          },
+        },
+      },
+    };
+
+    const findings = collectPRLevelFindings(reviewResults, aggregateResult);
+
+    expect(findings.summary).toBe('Aggregate summary');
+    expect(hasPRLevelFindings(findings)).toBe(true);
+    expect(findings.issues).toEqual([
+      expect.objectContaining({
+        source: 'cross-file',
+        severity: 'high',
+        description: 'State update is inconsistent across files',
+        files: ['src/a.js', 'src/unchanged-shared-state.js'],
+        suggestion: 'Use the shared state updater in both files.',
+      }),
+    ]);
+    expect(findings.recommendations).toEqual(['testing: Add an integration test']);
+  });
+
+  it('recognizes summary-only PR-level findings', () => {
+    const findings = collectPRLevelFindings([], {
+      prContext: {
+        holisticAnalysis: {
+          results: {
+            summary: 'The PR changes a shared integration flow.',
+            crossFileIssues: [],
+            recommendations: [],
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual({
+      summary: 'The PR changes a shared integration flow.',
+      issues: [],
+      recommendations: [],
+    });
+    expect(hasPRLevelFindings(findings)).toBe(true);
+  });
+});


### PR DESCRIPTION
The PR review output now surfaces holistic findings consistently across CLI outputs and GitHub comments.

- Adds shared review-result helpers to collect and dedupe PR-level cross-file findings separately from file-level issues.
- Includes holistic summaries, cross-file issues, and recommendations in JSON, Markdown, text, and GitHub summary comments.
- Keeps synthetic cross-chunk patterns out of issue totals while still surfacing them as recommendations.
- Avoids the contradictory GitHub summary state where summary-only or recommendation-only PR-level notes appeared under No Issues Found.
- Adds regression coverage for PR-level only, summary-only, and unchanged-file holistic finding scenarios.