### PR TITLE
Preserve JSON stdout output

### DIFF
--- a/src/embeddings/model-manager.js
+++ b/src/embeddings/model-manager.js
@@ -28,7 +28,7 @@ import { FASTEMBED_CACHE_DIR } from './constants.js';
 import { createModelInitializationError, createEmbeddingGenerationError } from './errors.js';
 
 // Load environment variables
-dotenv.config();
+dotenv.config({ quiet: true });
 
 // ============================================================================
 // MODEL MANAGER CLASS

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,9 @@ import { ProjectAnalyzer } from './project-analyzer.js';
 import { reviewFile, reviewFiles, reviewPullRequest } from './rag-review.js';
 import { execGitSafe } from './utils/command.js';
 import { ensureBranchExists, findBaseBranch } from './utils/git.js';
-import { verboseLog } from './utils/logging.js';
+import { diagnosticLog, isDebugEnabled, isVerboseEnabled, verboseLog } from './utils/logging.js';
 import { collectPRLevelFindings, getFileLevelIssueCount, hasPRLevelFindings } from './utils/review-results.js';
+import { configureCleanStdoutForDataOutput, isBrokenStdoutPipeError, writeStdout } from './utils/stdout.js';
 
 // Create a default embeddings system instance
 const embeddingsSystem = getDefaultEmbeddingsSystem();
@@ -213,7 +214,7 @@ else {
 
 // Register process event handlers for cleanup (embeddings cleanup primarily)
 process.on('SIGINT', async () => {
-  console.log(chalk.yellow('\nReceived SIGINT. Attempting graceful shutdown...'));
+  diagnosticLog(chalk.yellow('\nReceived SIGINT. Attempting graceful shutdown...'));
   // Set a timeout to force exit if cleanup hangs
   const forceExitTimeout = setTimeout(() => {
     console.error(chalk.red('Cleanup timed out after 10 seconds. Forcing exit...'));
@@ -221,23 +222,23 @@ process.on('SIGINT', async () => {
   }, 10000); // 10 seconds timeout
 
   try {
-    console.log(chalk.cyan('SIGINT handler: Attempting embeddingsSystem.cleanup()...'));
+    diagnosticLog(chalk.cyan('SIGINT handler: Attempting embeddingsSystem.cleanup()...'));
     await embeddingsSystem.cleanup();
-    console.log(chalk.green('embeddingsSystem.cleanup() completed.'));
+    diagnosticLog(chalk.green('embeddingsSystem.cleanup() completed.'));
     clearTimeout(forceExitTimeout); // Cleanup finished, clear the timeout
-    console.log(chalk.cyan('SIGINT handler: Exiting normally (code 0).'));
+    diagnosticLog(chalk.cyan('SIGINT handler: Exiting normally (code 0).'));
     process.exit(0); // Exit normally
   }
   catch (err) {
     console.error(chalk.red('Error during embeddingsSystem.cleanup():'), err.message);
     clearTimeout(forceExitTimeout);
-    console.log(chalk.cyan('SIGINT handler: Exiting after error (code 1).'));
+    diagnosticLog(chalk.cyan('SIGINT handler: Exiting after error (code 1).'));
     process.exit(1); // Exit with error code
   }
 });
 
 process.on('SIGTERM', async () => {
-  console.log(chalk.yellow('\nReceived SIGTERM. Attempting graceful shutdown...'));
+  diagnosticLog(chalk.yellow('\nReceived SIGTERM. Attempting graceful shutdown...'));
   // Set a timeout to force exit if cleanup hangs
   const forceExitTimeout = setTimeout(() => {
     console.error(chalk.red('Cleanup timed out after 10 seconds. Forcing exit...'));
@@ -245,17 +246,17 @@ process.on('SIGTERM', async () => {
   }, 10000);
 
   try {
-    console.log(chalk.cyan('SIGTERM handler: Attempting embeddingsSystem.cleanup()...'));
+    diagnosticLog(chalk.cyan('SIGTERM handler: Attempting embeddingsSystem.cleanup()...'));
     await embeddingsSystem.cleanup();
-    console.log(chalk.green('embeddingsSystem.cleanup() completed.'));
+    diagnosticLog(chalk.green('embeddingsSystem.cleanup() completed.'));
     clearTimeout(forceExitTimeout); // Cleanup finished, clear the timeout
-    console.log(chalk.cyan('SIGTERM handler: Exiting normally (code 0).'));
+    diagnosticLog(chalk.cyan('SIGTERM handler: Exiting normally (code 0).'));
     process.exit(0); // Exit normally
   }
   catch (err) {
     console.error(chalk.red('Error during embeddingsSystem.cleanup():'), err.message);
     clearTimeout(forceExitTimeout);
-    console.log(chalk.cyan('SIGTERM handler: Exiting after error (code 1).'));
+    diagnosticLog(chalk.cyan('SIGTERM handler: Exiting after error (code 1).'));
     process.exit(1); // Exit with error code
   }
 });
@@ -263,7 +264,7 @@ process.on('SIGTERM', async () => {
 // Ensure cleanup on normal exit
 process.on('exit', () => {
   // Note: Async cleanup might not fully complete here
-  console.log(chalk.cyan('Exiting...'));
+  diagnosticLog(chalk.cyan('Exiting...'));
 });
 
 // REMOVED: Old options processing logic for ignore/severity
@@ -273,6 +274,7 @@ process.on('exit', () => {
 
 // Main function to run the code review (Refactored to use cag-review.js)
 async function runCodeReview(options) {
+  configureCleanStdoutForDataOutput(options);
   let reviewTask = null;
   let operationDescription = '';
   const startTime = Date.now();
@@ -281,7 +283,7 @@ async function runCodeReview(options) {
   // If --directory is specified, use that as the project directory
   // Otherwise, use the current working directory
   const projectPath = options.directory ? path.resolve(options.directory) : process.cwd();
-  console.log(chalk.gray(`Using project path for analysis: ${projectPath}`));
+  diagnosticLog(chalk.gray(`Using project path for analysis: ${projectPath}`));
 
   // Parse custom documents
   const customDocs = [];
@@ -322,12 +324,12 @@ async function runCodeReview(options) {
         .trim(); // Remove leading/trailing whitespace
 
       customDocs.push({ title, content });
-      console.log(chalk.gray(`Loaded custom document '${title}' from ${filePath} (${content.length} chars)`));
+      diagnosticLog(chalk.gray(`Loaded custom document '${title}' from ${filePath} (${content.length} chars)`));
 
       // Debug: Show a clean preview of the content
       const previewLength = 200;
       const preview = content.substring(0, previewLength).replace(/\n/g, '\\n');
-      console.log(chalk.gray(`  Content preview: ${preview}${content.length > previewLength ? '...' : ''}`));
+      diagnosticLog(chalk.gray(`  Content preview: ${preview}${content.length > previewLength ? '...' : ''}`));
     }
   }
 
@@ -352,7 +354,7 @@ async function runCodeReview(options) {
   };
 
   try {
-    console.log(chalk.bold.blue('AI Code Review (RAG Approach) - Starting analysis...'));
+    diagnosticLog(chalk.bold.blue('AI Code Review (RAG Approach) - Starting analysis...'));
 
     // Determine the review mode based on options
     // Only support: single file, specific files, or diff with branch
@@ -361,7 +363,9 @@ async function runCodeReview(options) {
       const gitWorkingDir = options.directory ? path.resolve(options.directory) : process.cwd();
       const changedFiles = getChangedFiles(options.diffWith, gitWorkingDir);
       if (changedFiles.length === 0) {
-        console.log(chalk.yellow(`No changed files found compared to branch '${options.diffWith}'. Exiting.`));
+        const message = `No changed files found compared to branch '${options.diffWith}'. Exiting.`;
+        diagnosticLog(chalk.yellow(message));
+        await emitEmptyReviewOutputIfNeeded(options, { success: true, results: [], message });
         return;
       }
       operationDescription = `${changedFiles.length} files changed vs ${options.diffWith}`;
@@ -383,7 +387,9 @@ async function runCodeReview(options) {
     else if (options.files && options.files.length > 0) {
       const filesToAnalyze = await expandFilePatterns(options.files);
       if (filesToAnalyze.length === 0) {
-        console.log(chalk.yellow('No files found matching the specified patterns. Exiting.'));
+        const message = 'No files found matching the specified patterns. Exiting.';
+        diagnosticLog(chalk.yellow(message));
+        await emitEmptyReviewOutputIfNeeded(options, { success: true, results: [], message });
         return;
       }
       operationDescription = `${filesToAnalyze.length} specific files/patterns`;
@@ -408,7 +414,7 @@ async function runCodeReview(options) {
       process.exit(1);
     }
 
-    console.log(chalk.cyan(`Starting review for ${operationDescription}...`));
+    diagnosticLog(chalk.cyan(`Starting review for ${operationDescription}...`));
 
     // Execute the selected review task
     const reviewResult = await reviewTask;
@@ -421,60 +427,77 @@ async function runCodeReview(options) {
     // Process and output results
     if (reviewResult && reviewResult.success) {
       if (reviewResult.results && reviewResult.results.length > 0) {
-        console.log(chalk.green(`Found ${reviewResult.results.length} result items to display`));
-        // Determine output function based on format option
-        const outputFn = options.output === 'json' ? outputJson : options.output === 'markdown' ? outputMarkdown : outputText;
-        // Pass the detailed results array to the output function
-        outputFn(reviewResult.results, options, reviewResult);
-        console.log(chalk.bold.green(`\nAnalysis complete for ${operationDescription}! (${duration}s)`));
+        diagnosticLog(chalk.green(`Found ${reviewResult.results.length} result items to display`));
+        await outputReviewResults(reviewResult.results, options, reviewResult);
+        diagnosticLog(chalk.bold.green(`\nAnalysis complete for ${operationDescription}! (${duration}s)`));
       }
       else {
         // No results to display (e.g., all files were excluded/skipped)
         const message = reviewResult.message || 'All files were excluded from review (e.g., config files, lock files).';
-        console.log(chalk.yellow(message));
+        diagnosticLog(chalk.yellow(message));
 
-        // Still output empty results if outputFile is specified (for CI/CD pipelines)
-        if (options.outputFile) {
-          const outputFn = options.output === 'json' ? outputJson : options.output === 'markdown' ? outputMarkdown : outputText;
-          outputFn([], options, reviewResult);
-          console.log(chalk.yellow(`Empty results written to: ${options.outputFile}`));
+        if (await emitEmptyReviewOutputIfNeeded(options, reviewResult)) {
+          if (options.outputFile) {
+            diagnosticLog(chalk.yellow(`Empty results written to: ${options.outputFile}`));
+          }
         }
 
-        console.log(chalk.bold.yellow(`\nReview complete for ${operationDescription} - no reviewable files found (${duration}s)`));
+        diagnosticLog(chalk.bold.yellow(`\nReview complete for ${operationDescription} - no reviewable files found (${duration}s)`));
       }
     }
     else {
+      const error = reviewResult?.error || 'Code review process failed.';
       console.error(chalk.red('\nCode review process failed.'));
-      if (reviewResult && reviewResult.error) {
-        console.error(chalk.red(`Error: ${reviewResult.error}`));
+      console.error(chalk.red(`Error: ${error}`));
+
+      if (await emitErrorReviewOutputIfNeeded(options, error, reviewResult || {})) {
+        if (options.outputFile) {
+          diagnosticLog(chalk.yellow(`Error results written to: ${options.outputFile}`));
+        }
       }
+      // AI review output is advisory; report review-task failures without failing CI.
     }
 
     // Clean up resources
-    console.log(chalk.cyan('Cleaning up resources...'));
+    diagnosticLog(chalk.cyan('Cleaning up resources...'));
     try {
       await embeddingsSystem.cleanup();
       await cleanupClassifier();
-      console.log(chalk.green('All resources cleaned up successfully'));
+      diagnosticLog(chalk.green('All resources cleaned up successfully'));
     }
     catch (cleanupErr) {
       console.error(chalk.yellow('Error during cleanup:'), cleanupErr.message);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   }
   catch (err) {
-    console.error(chalk.red(`\nError during code review (${operationDescription}):`), err.message);
-    console.error(err.stack);
+    if (!isBrokenStdoutPipeError(err)) {
+      console.error(chalk.red(`\nError during code review (${operationDescription}):`), err.message);
+      if (shouldPrintErrorStack(options, err)) {
+        console.error(err.stack);
+      }
+    }
+
+    try {
+      await emitErrorReviewOutputIfNeeded(options, err.message, { success: false, error: err.message });
+    }
+    catch (outputErr) {
+      if (!isBrokenStdoutPipeError(outputErr)) {
+        console.error(chalk.red('Error writing review error output:'), outputErr.message);
+      }
+    }
+
     // Clean up resources even on error
     try {
       await embeddingsSystem.cleanup();
       await cleanupClassifier();
-      console.log(chalk.green('All resources cleaned up successfully'));
+      diagnosticLog(chalk.green('All resources cleaned up successfully'));
     }
     catch (cleanupErr) {
       console.error(chalk.red('Error during cleanup:'), cleanupErr.message);
     }
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 
@@ -961,7 +984,7 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
   try {
     // Get git root directory
     const gitRoot = execSync('git rev-parse --show-toplevel', { cwd: workingDir }).toString().trim();
-    console.log(chalk.gray(`Git repository: ${gitRoot}`));
+    diagnosticLog(chalk.gray(`Git repository: ${gitRoot}`));
 
     // Ensure the branch exists locally (fetch if needed)
     ensureBranchExists(branch, workingDir);
@@ -978,7 +1001,7 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
       // Continue with the original baseBranch name, it might work with remote refs
     }
 
-    console.log(chalk.gray(`Comparing ${branch} against ${baseBranch}...`));
+    diagnosticLog(chalk.gray(`Comparing ${branch} against ${baseBranch}...`));
 
     // Use three-dot notation to get changes in branch compared to base
     // This shows commits that are in 'branch' but not in 'baseBranch'
@@ -992,7 +1015,7 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
       .map((file) => path.resolve(gitRoot, file)); // Get absolute path
 
     if (changedFiles.length > 0) {
-      console.log(chalk.gray(`Found ${changedFiles.length} changed files in ${branch} vs ${baseBranch}`));
+      diagnosticLog(chalk.gray(`Found ${changedFiles.length} changed files in ${branch} vs ${baseBranch}`));
     }
 
     return changedFiles;
@@ -1009,6 +1032,58 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
 // --- Output Formatting Functions --- //
 // These consume the normalized results returned by the RAG review pipeline
 
+function getReviewOutputFunction(outputFormat) {
+  if (outputFormat === 'json') {
+    return outputJson;
+  }
+  if (outputFormat === 'markdown') {
+    return outputMarkdown;
+  }
+  return outputText;
+}
+
+function shouldEmitReviewOutput(options = {}) {
+  return Boolean(options.outputFile || options.output === 'json' || options.output === 'markdown');
+}
+
+function shouldPrintErrorStack(options, error) {
+  return Boolean(error?.stack && (isVerboseEnabled(options) || isDebugEnabled()));
+}
+
+async function outputReviewResults(reviewResults, options, aggregateResult = {}) {
+  await getReviewOutputFunction(options.output)(reviewResults, options, aggregateResult);
+}
+
+async function emitEmptyReviewOutputIfNeeded(options, aggregateResult = {}) {
+  if (!shouldEmitReviewOutput(options)) {
+    return false;
+  }
+
+  await outputReviewResults([], options, aggregateResult);
+  return true;
+}
+
+async function emitErrorReviewOutputIfNeeded(options, error, aggregateResult = {}) {
+  if (!shouldEmitReviewOutput(options)) {
+    return false;
+  }
+
+  await outputReviewResults([createReviewErrorResult(error)], options, {
+    ...aggregateResult,
+    success: false,
+    error,
+  });
+  return true;
+}
+
+function createReviewErrorResult(error) {
+  return {
+    filePath: 'review',
+    success: false,
+    error,
+  };
+}
+
 /**
  * Output results in JSON format
  *
@@ -1016,7 +1091,7 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
  * @param {Object} options - Command line options
  * @param {Object} aggregateResult - Full review result with PR-level context
  */
-function outputJson(reviewResults, options, aggregateResult = {}) {
+async function outputJson(reviewResults, options, aggregateResult = {}) {
   const prLevelFindings = collectPRLevelFindings(reviewResults, aggregateResult);
   const fileLevelIssues = getFileLevelIssueCount(reviewResults);
 
@@ -1069,7 +1144,7 @@ function outputJson(reviewResults, options, aggregateResult = {}) {
   }
   else {
     // Write JSON output to stdout (process.stdout is not buffered)
-    process.stdout.write(jsonOutput);
+    await writeStdout(jsonOutput);
   }
 }
 
@@ -1080,7 +1155,7 @@ function outputJson(reviewResults, options, aggregateResult = {}) {
  * @param {Object} options - Command line options
  * @param {Object} aggregateResult - Full review result with PR-level context
  */
-function outputMarkdown(reviewResults, options, aggregateResult = {}) {
+async function outputMarkdown(reviewResults, options, aggregateResult = {}) {
   const totalFiles = reviewResults.length;
   const filesWithIssues = reviewResults.filter((r) => r.success && !r.skipped && r.results?.issues?.length > 0).length;
   const skippedFiles = reviewResults.filter((r) => r.skipped).length;
@@ -1164,7 +1239,7 @@ function outputMarkdown(reviewResults, options, aggregateResult = {}) {
     return;
   }
 
-  process.stdout.write(markdownOutput);
+  await writeStdout(markdownOutput);
 }
 
 /**

--- a/src/llm.js
+++ b/src/llm.js
@@ -18,7 +18,7 @@ import dotenv from 'dotenv';
 import { verboseLog } from './utils/logging.js';
 
 // Load env variables if present; do not enforce key at import time
-dotenv.config();
+dotenv.config({ quiet: true });
 
 let anthropic = null;
 

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -6,6 +6,9 @@
  */
 
 import chalk from 'chalk';
+import { diagnosticLog } from './stdout.js';
+
+export { diagnosticLog };
 
 /**
  * Determine whether verbose logging is enabled.
@@ -33,11 +36,11 @@ export function isDebugEnabled() {
  * Log only when verbose output is enabled.
  *
  * @param {Object|boolean} options - Options object or boolean verbose flag
- * @param {...any} args - Arguments to pass to console.log
+ * @param {...any} args - Arguments to pass to the diagnostic log sink
  */
 export function verboseLog(options, ...args) {
   if (isVerboseEnabled(options)) {
-    console.log(...args);
+    diagnosticLog(...args);
   }
 }
 
@@ -52,6 +55,6 @@ export function verboseLog(options, ...args) {
  */
 export function debug(message) {
   if (isDebugEnabled()) {
-    console.log(chalk.cyan(`[DEBUG] ${message}`));
+    diagnosticLog(chalk.cyan(`[DEBUG] ${message}`));
   }
 }

--- a/src/utils/logging.test.js
+++ b/src/utils/logging.test.js
@@ -1,4 +1,5 @@
 import { debug, verboseLog, isDebugEnabled, isVerboseEnabled } from './logging.js';
+import { configureCleanStdoutForDataOutput, resetCleanStdoutForDataOutput } from './stdout.js';
 
 describe('logging', () => {
   let originalEnv;
@@ -13,6 +14,7 @@ describe('logging', () => {
   afterEach(() => {
     process.env = originalEnv;
     process.argv = originalArgv;
+    resetCleanStdoutForDataOutput();
   });
 
   describe('debug', () => {
@@ -59,6 +61,16 @@ describe('logging', () => {
       debug('Test');
 
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[DEBUG]'));
+    });
+
+    it('should write debug diagnostics to stderr when stdout is reserved for JSON', () => {
+      process.env.DEBUG = 'true';
+      configureCleanStdoutForDataOutput({ output: 'json' });
+
+      debug('Debug message');
+
+      expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('Debug message'));
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Debug message'));
     });
   });
 
@@ -121,6 +133,15 @@ describe('logging', () => {
       verboseLog({ verbose: true }, 'Option verbose message');
 
       expect(console.log).toHaveBeenCalledWith('Option verbose message');
+    });
+
+    it('should write verbose diagnostics to stderr when stdout is reserved for JSON', () => {
+      configureCleanStdoutForDataOutput({ output: 'json' });
+
+      verboseLog({ verbose: true }, 'Option verbose message');
+
+      expect(console.log).not.toHaveBeenCalledWith('Option verbose message');
+      expect(console.error).toHaveBeenCalledWith('Option verbose message');
     });
 
     it('should not log when only DEBUG is set', () => {

--- a/src/utils/stdout.js
+++ b/src/utils/stdout.js
@@ -1,0 +1,77 @@
+const STDOUT_DATA_OUTPUT_FORMATS = new Set(['json', 'markdown']);
+const stdoutErrorHandlerInstalled = new WeakSet();
+
+let routeDiagnosticsToStderr = false;
+
+export function shouldRouteLogsToStderrForOutput(options = {}) {
+  return Boolean(!options.outputFile && STDOUT_DATA_OUTPUT_FORMATS.has(options.output));
+}
+
+export function configureCleanStdoutForDataOutput(options = {}) {
+  routeDiagnosticsToStderr = shouldRouteLogsToStderrForOutput(options);
+  return routeDiagnosticsToStderr;
+}
+
+export function resetCleanStdoutForDataOutput() {
+  routeDiagnosticsToStderr = false;
+}
+
+export function areDiagnosticsRoutedToStderr() {
+  return routeDiagnosticsToStderr;
+}
+
+export function diagnosticLog(...args) {
+  if (routeDiagnosticsToStderr) {
+    console.error(...args);
+  }
+  else {
+    console.log(...args);
+  }
+}
+
+export function isBrokenStdoutPipeError(error) {
+  return error?.code === 'EPIPE' || error?.code === 'ERR_STREAM_DESTROYED';
+}
+
+export function installStdoutErrorHandler(stdout = process.stdout) {
+  if (stdoutErrorHandlerInstalled.has(stdout)) {
+    return false;
+  }
+
+  stdout.on('error', (error) => {
+    if (isBrokenStdoutPipeError(error)) {
+      return;
+    }
+
+    throw error;
+  });
+  stdoutErrorHandlerInstalled.add(stdout);
+  return true;
+}
+
+export function writeStdout(content) {
+  return new Promise((resolve, reject) => {
+    const handleWriteError = (error) => {
+      if (!error) {
+        resolve(true);
+        return;
+      }
+
+      if (isBrokenStdoutPipeError(error)) {
+        resolve(false);
+        return;
+      }
+
+      reject(error);
+    };
+
+    try {
+      process.stdout.write(content, handleWriteError);
+    }
+    catch (error) {
+      handleWriteError(error);
+    }
+  });
+}
+
+installStdoutErrorHandler();

--- a/src/utils/stdout.test.js
+++ b/src/utils/stdout.test.js
@@ -1,0 +1,216 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import ts from 'typescript';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  areDiagnosticsRoutedToStderr,
+  configureCleanStdoutForDataOutput,
+  diagnosticLog,
+  installStdoutErrorHandler,
+  isBrokenStdoutPipeError,
+  resetCleanStdoutForDataOutput,
+  shouldRouteLogsToStderrForOutput,
+  writeStdout,
+} from './stdout.js';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const reviewPipelineRoots = ['src/rag-review.js'];
+const stdoutSinkAllowlist = new Set(['src/utils/stdout.js']);
+
+function readProjectFile(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
+}
+
+function toProjectRelativePath(absolutePath) {
+  return path.relative(projectRoot, absolutePath).replaceAll(path.sep, '/');
+}
+
+function resolveLocalImport(importer, specifier) {
+  if (!specifier.startsWith('.')) {
+    return null;
+  }
+
+  const importerDir = path.dirname(path.join(projectRoot, importer));
+  const resolved = path.resolve(importerDir, specifier);
+  const filePath = resolved.endsWith('.js') ? resolved : `${resolved}.js`;
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  return toProjectRelativePath(filePath);
+}
+
+function parseModule(relativePath) {
+  return ts.createSourceFile(relativePath, readProjectFile(relativePath), ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+}
+
+function walkAst(node, visitor) {
+  visitor(node);
+  ts.forEachChild(node, (child) => walkAst(child, visitor));
+}
+
+function getReviewPipelineFiles() {
+  const visited = new Set();
+  const pending = [...reviewPipelineRoots];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (visited.has(current)) {
+      continue;
+    }
+
+    visited.add(current);
+    const ast = parseModule(current);
+
+    walkAst(ast, (node) => {
+      if (!ts.isImportDeclaration(node) && !ts.isExportDeclaration(node)) {
+        return;
+      }
+
+      const specifier = node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier) ? node.moduleSpecifier.text : null;
+      if (typeof specifier !== 'string') {
+        return;
+      }
+
+      const importedFile = resolveLocalImport(current, specifier);
+      if (importedFile && !importedFile.endsWith('.test.js')) {
+        pending.push(importedFile);
+      }
+    });
+  }
+
+  return [...visited].sort();
+}
+
+function isForbiddenStdoutCall(node) {
+  if (ts.isNewExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === 'Spinner') {
+    return true;
+  }
+
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  const propertyName = node.expression.name.text;
+  const object = node.expression.expression;
+
+  if (ts.isIdentifier(object) && object.text === 'console' && ['log', 'info'].includes(propertyName)) {
+    return true;
+  }
+
+  return (
+    ts.isPropertyAccessExpression(object) &&
+    ts.isIdentifier(object.expression) &&
+    object.expression.text === 'process' &&
+    object.name.text === 'stdout' &&
+    propertyName === 'write'
+  );
+}
+
+function findForbiddenStdoutCall(source) {
+  let forbiddenCall = null;
+
+  walkAst(source, (node) => {
+    if (!forbiddenCall && isForbiddenStdoutCall(node)) {
+      forbiddenCall = node;
+    }
+  });
+
+  return forbiddenCall;
+}
+
+describe('stdout utilities', () => {
+  afterEach(() => {
+    resetCleanStdoutForDataOutput();
+    vi.restoreAllMocks();
+  });
+
+  it('routes diagnostics to stderr only for data formats written to stdout', () => {
+    expect(shouldRouteLogsToStderrForOutput({ output: 'json' })).toBe(true);
+    expect(shouldRouteLogsToStderrForOutput({ output: 'markdown' })).toBe(true);
+    expect(shouldRouteLogsToStderrForOutput({ output: 'text' })).toBe(false);
+    expect(shouldRouteLogsToStderrForOutput({ output: 'json', outputFile: 'review.json' })).toBe(false);
+  });
+
+  it('keeps stdout reserved for data payloads while routing diagnostics to stderr', () => {
+    const logSpy = vi.spyOn(console, 'log');
+    const errorSpy = vi.spyOn(console, 'error');
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    configureCleanStdoutForDataOutput({ output: 'json' });
+    diagnosticLog('Starting review...');
+    process.stdout.write('{"ok":true}');
+
+    expect(logSpy).not.toHaveBeenCalledWith('Starting review...');
+    expect(errorSpy).toHaveBeenCalledWith('Starting review...');
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('{"ok":true}');
+  });
+
+  it('keeps diagnostic routing active until explicitly reset', () => {
+    configureCleanStdoutForDataOutput({ output: 'json' });
+
+    expect(areDiagnosticsRoutedToStderr()).toBe(true);
+
+    resetCleanStdoutForDataOutput();
+    expect(areDiagnosticsRoutedToStderr()).toBe(false);
+  });
+
+  it('treats broken stdout pipes as completed writes', async () => {
+    const error = Object.assign(new Error('broken pipe'), { code: 'EPIPE' });
+    vi.spyOn(process.stdout, 'write').mockImplementation((_content, callback) => {
+      callback(error);
+      return false;
+    });
+
+    await expect(writeStdout('{"ok":true}')).resolves.toBe(false);
+    expect(isBrokenStdoutPipeError(error)).toBe(true);
+  });
+
+  it('treats synchronously thrown broken stdout pipe errors as completed writes', async () => {
+    const error = Object.assign(new Error('stream destroyed'), { code: 'ERR_STREAM_DESTROYED' });
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+      throw error;
+    });
+
+    await expect(writeStdout('{"ok":true}')).resolves.toBe(false);
+    expect(isBrokenStdoutPipeError(error)).toBe(true);
+  });
+
+  it('rejects non-pipe stdout write failures', async () => {
+    const error = Object.assign(new Error('disk is haunted'), { code: 'EIO' });
+    vi.spyOn(process.stdout, 'write').mockImplementation((_content, callback) => {
+      callback(error);
+      return false;
+    });
+
+    await expect(writeStdout('{"ok":true}')).rejects.toThrow('disk is haunted');
+  });
+
+  it('swallows emitted broken stdout pipe errors', () => {
+    const stdout = new EventEmitter();
+    installStdoutErrorHandler(stdout);
+
+    expect(() => stdout.emit('error', Object.assign(new Error('broken pipe'), { code: 'EPIPE' }))).not.toThrow();
+  });
+
+  it('throws emitted non-pipe stdout errors', () => {
+    const stdout = new EventEmitter();
+    installStdoutErrorHandler(stdout);
+
+    expect(() => stdout.emit('error', Object.assign(new Error('disk is haunted'), { code: 'EIO' }))).toThrow('disk is haunted');
+  });
+
+  it('keeps review pipeline diagnostics off raw stdout', () => {
+    for (const file of getReviewPipelineFiles()) {
+      if (stdoutSinkAllowlist.has(file)) {
+        continue;
+      }
+
+      const forbiddenCall = findForbiddenStdoutCall(parseModule(file));
+      expect(forbiddenCall, `${file} should use diagnosticLog/verboseLog/debug for diagnostics`).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
This PR keeps structured CLI output parseable when users redirect or pipe `codecritique analyze --output json`.

- Routes analyze diagnostics through a stderr-aware diagnostic sink while leaving JSON and Markdown payload writes on stdout.
- Emits structured JSON for empty/no-reviewable review results and review errors instead of leaving redirected stdout empty.
- Awaits stdout payload writes and handles broken-pipe conditions without noisy stack traces or unhandled rejections.
- Keeps AI review findings and soft review-task errors advisory, so the review workflow does not fail just because issues were reported.
- Quietly loads dotenv during startup so import-time environment banners cannot contaminate redirected JSON.
- Adds guardrail tests to keep review-pipeline diagnostics off raw stdout and cover broken-pipe stdout behavior.