### PR TITLE
Review target branches against correct base

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -144,6 +144,49 @@ runs:
           ${{ env.FEEDBACK_CACHE_KEY }}-
       continue-on-error: true
 
+    # Parent auto-detection (findParentBranch) diffs the PR head against the
+    # branch it was forked from. On pull_request that parent is the PR base, which
+    # for a stacked PR is another feature branch -- not main. The default checkout
+    # is shallow and only has the PR head, so the base is missing and detection
+    # would fall back to main. Fetch the base (and main as fallback) here.
+    #
+    # We deliberately avoid `fetch-depth: 0` (a full clone is slow on large/old
+    # repos) and instead deepen incrementally only until the merge-base with the
+    # base is reachable -- the minimum history needed for correct ancestry checks
+    # on a shallow checkout. On a complete checkout this loop is skipped entirely.
+    - name: Fetch base branch for parent detection
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        HEAD_REF: ${{ github.head_ref }}
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        # Nothing to set up when there is no PR head (e.g. push events).
+        [ -z "$HEAD_REF" ] && exit 0
+
+        # Fetch the PR head and its base into remote-tracking refs (candidates
+        # that findParentBranch reads), plus main as the fallback base.
+        git fetch --no-tags --prune origin \
+          "+refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" \
+          ${BASE_REF:+"+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"} 2>/dev/null || true
+        git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main" 2>/dev/null || true
+
+        # Deepen the head's history until the merge-base with the selected diff
+        # base is present, capped, with a full fetch only as a last resort.
+        DIFF_BASE="origin/${BASE_REF:-main}"
+        if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+          depth=50
+          while ! git merge-base "$DIFF_BASE" "origin/${HEAD_REF}" >/dev/null 2>&1; do
+            git fetch --no-tags --deepen="$depth" origin \
+              "+refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}" 2>/dev/null || true
+            depth=$((depth * 2))
+            if [ "$depth" -gt 4096 ]; then
+              git fetch --no-tags --unshallow origin 2>/dev/null || true
+              break
+            fi
+          done
+        fi
+
     - name: Run AI Code Review
       id: review
       shell: bash
@@ -152,12 +195,20 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+        BASE_REF: ${{ github.base_ref }}
         CI: true
         DEBUG: ${{ inputs.verbose }}
         VERBOSE: ${{ inputs.verbose }}
       run: |
         # Build CLI command arguments safely - avoid eval/string interpolation.
         CLI_ARGS=("analyze" "-b" "${{ github.head_ref }}" "--directory" "$GITHUB_WORKSPACE")
+
+        # In CI the PR base is authoritative -- pass it as the diff base so the
+        # review uses it directly instead of inferring the parent (which skips a
+        # base that has advanced past the fork point). Empty on push events.
+        if [ -n "$BASE_REF" ]; then
+          CLI_ARGS+=("--base" "$BASE_REF")
+        fi
 
         # Add output format and output file (always JSON)
         CLI_ARGS+=("--output" "json" "--output-file" "review_output.json")

--- a/README.md
+++ b/README.md
@@ -263,8 +263,13 @@ npx codecritique analyze --file src/components/Button.tsx
 # Analyze files matching patterns
 npx codecritique analyze --files "src/**/*.ts" "lib/*.js"
 
-# Analyze changes in feature-branch vs main branch (auto-detects base branch)
+# Review changes in a target branch against its auto-detected parent branch
 npx codecritique analyze --diff-with feature-branch
+
+# Review against an explicit base branch (overrides auto-detection).
+# Useful for stacked PRs where you know the real base, or in CI where the PR
+# base ref is authoritative.
+npx codecritique analyze --diff-with feature-B --base feature-A
 ```
 
 #### Using with Custom Guidelines
@@ -383,9 +388,6 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup master branch for diff analysis
-        run: git fetch --no-tags --prune origin main:main
-
       - name: Code Review
         uses: cosmocoder/CodeCritique/.github/actions/pr-review@main
         with:
@@ -393,11 +395,16 @@ jobs:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
+> No manual `git fetch` or `fetch-depth: 0` is needed. The action fetches the PR base
+> branch (the parent — which for a stacked PR is another feature branch) and deepens
+> the shallow checkout just enough to compute the diff, so parent auto-detection works
+> without the cost of a full-history clone.
+
 #### Required Setup
 
 1. **Anthropic API Key**: Store your Anthropic API key as a repository secret named `ANTHROPIC_API_KEY`
 2. **Permissions**: The workflow must have `contents: write`, `actions: read`, and `pull-requests: write` permissions
-3. **Git Setup**: Ensure the base branch is available for diff analysis (see example above)
+3. **Git Setup**: None required — the action fetches the PR base/parent branch and deepens the checkout only as much as the diff needs (no `fetch-depth: 0`)
 
 #### Input Parameters
 
@@ -450,7 +457,7 @@ codecritique analyze --file src/components/Button.tsx
 # Analyze files matching patterns
 codecritique analyze --files "src/**/*.ts" "lib/*.js"
 
-# Analyze branch diff
+# Review target branch changes against its auto-detected parent branch
 codecritique analyze --diff-with feature-branch
 
 # Generate embeddings

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -10,27 +10,28 @@ codecritique analyze [options]
 
 ### Options
 
-| Option                            | Description                                                                                              | Default       |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------- |
-| `-b, --diff-with <branch>`        | Analyze files changed in the specified branch compared to the base branch (main/master)                  | -             |
-| `-f, --files <files...>`          | Specific files or glob patterns to review                                                                | -             |
-| `--file <file>`                   | Analyze a single file                                                                                    | -             |
-| `-d, --directory <dir>`           | Working directory for git operations (use with --diff-with)                                              | -             |
-| `-o, --output <format>`           | Output format (text, json, markdown)                                                                     | `text`        |
-| `--output-file <file>`            | Save output to file (useful with --output json)                                                          | -             |
-| `--no-color`                      | Disable colored output                                                                                   | `false`       |
-| `--verbose`                       | Show verbose output                                                                                      | `false`       |
-| `--model <model>`                 | LLM model to use (e.g., claude-sonnet-4-5)                                                               | Auto-selected |
-| `--temperature <number>`          | LLM temperature                                                                                          | `0.2`         |
-| `--max-tokens <number>`           | LLM max tokens                                                                                           | `8192`        |
-| `--cache-ttl <ttl>`               | Cache TTL for LLM prompts: "5m" (default, no extra cost) or "1h" (extended, extra cost for cache writes) | `5m`          |
-| `--similarity-threshold <number>` | Threshold for finding similar code examples                                                              | `0.6`         |
-| `--max-examples <number>`         | Max similar code examples to use                                                                         | `5`           |
-| `--concurrency <number>`          | Concurrency for processing multiple files                                                                | `3`           |
-| `--doc <specs...>`                | Custom documents to provide to LLM (format: "Title:./path/to/file.md"). Can be specified multiple times. | -             |
-| `--feedback-path <path>`          | Path to feedback artifacts directory for filtering dismissed issues                                      | -             |
-| `--track-feedback`                | Enable feedback-aware analysis to avoid previously dismissed issues                                      | `false`       |
-| `--feedback-threshold <number>`   | Similarity threshold for feedback filtering (0-1)                                                        | `0.7`         |
+| Option                            | Description                                                                                                                                   | Default       |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `-b, --diff-with <branch>`        | Review the specified target branch against its auto-detected parent branch (the branch it was forked from; falls back to main/master/develop) | -             |
+| `--base <branch>`                 | Base branch to diff the target against, overriding auto-detection (e.g. the authoritative PR base ref in CI). Use with `--diff-with`          | -             |
+| `-f, --files <files...>`          | Specific files or glob patterns to review                                                                                                     | -             |
+| `--file <file>`                   | Analyze a single file                                                                                                                         | -             |
+| `-d, --directory <dir>`           | Working directory for git operations (use with --diff-with)                                                                                   | -             |
+| `-o, --output <format>`           | Output format (text, json, markdown)                                                                                                          | `text`        |
+| `--output-file <file>`            | Save output to file (useful with --output json)                                                                                               | -             |
+| `--no-color`                      | Disable colored output                                                                                                                        | `false`       |
+| `--verbose`                       | Show verbose output                                                                                                                           | `false`       |
+| `--model <model>`                 | LLM model to use (e.g., claude-sonnet-4-5)                                                                                                    | Auto-selected |
+| `--temperature <number>`          | LLM temperature                                                                                                                               | `0.2`         |
+| `--max-tokens <number>`           | LLM max tokens                                                                                                                                | `8192`        |
+| `--cache-ttl <ttl>`               | Cache TTL for LLM prompts: "5m" (default, no extra cost) or "1h" (extended, extra cost for cache writes)                                      | `5m`          |
+| `--similarity-threshold <number>` | Threshold for finding similar code examples                                                                                                   | `0.6`         |
+| `--max-examples <number>`         | Max similar code examples to use                                                                                                              | `5`           |
+| `--concurrency <number>`          | Concurrency for processing multiple files                                                                                                     | `3`           |
+| `--doc <specs...>`                | Custom documents to provide to LLM (format: "Title:./path/to/file.md"). Can be specified multiple times.                                      | -             |
+| `--feedback-path <path>`          | Path to feedback artifacts directory for filtering dismissed issues                                                                           | -             |
+| `--track-feedback`                | Enable feedback-aware analysis to avoid previously dismissed issues                                                                           | `false`       |
+| `--feedback-threshold <number>`   | Similarity threshold for feedback filtering (0-1)                                                                                             | `0.7`         |
 
 ### Examples
 
@@ -41,8 +42,12 @@ codecritique analyze --file src/components/Button.tsx
 # Analyze multiple files with patterns
 codecritique analyze --files "src/**/*.tsx" "lib/*.js"
 
-# Analyze changes in feature-branch vs main branch (auto-detects base branch)
+# Review changes in a target branch against its auto-detected parent branch
 codecritique analyze --diff-with feature-branch
+
+# Review against an explicit base branch (overrides auto-detection; useful for
+# stacked PRs or in CI where the PR base ref is authoritative)
+codecritique analyze --diff-with feature-B --base feature-A
 
 # Analyze with custom documentation
 codecritique analyze --file src/utils/validation.ts \

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ import { cleanupClassifier, clearPRComments, getPRCommentsStats, hasPRComments }
 import { ProjectAnalyzer } from './project-analyzer.js';
 import { reviewFile, reviewFiles, reviewPullRequest } from './rag-review.js';
 import { execGitSafe } from './utils/command.js';
-import { ensureBranchExists, findBaseBranch } from './utils/git.js';
+import { ensureBranchExists, findParentBranch } from './utils/git.js';
 import { diagnosticLog, isDebugEnabled, isVerboseEnabled, verboseLog } from './utils/logging.js';
 import { collectPRLevelFindings, getFileLevelIssueCount, hasPRLevelFindings } from './utils/review-results.js';
 import { configureCleanStdoutForDataOutput, isBrokenStdoutPipeError, writeStdout } from './utils/stdout.js';
@@ -46,7 +46,11 @@ program.name('codecritique').description('CLI tool for AI-powered code review us
 program
   .command('analyze')
   .description('Analyze code using dynamic context (RAG approach)')
-  .option('-b, --diff-with <branch>', 'Analyze files changed compared to a branch (triggers PR review mode)')
+  .option(
+    '-b, --diff-with <branch>',
+    'Review the specified target branch against its auto-detected parent branch (triggers PR review mode)'
+  )
+  .option('--base <branch>', 'Base branch to diff the target against, overriding auto-detection (e.g. the authoritative PR base ref in CI)')
   .option('-f, --files <files...>', 'Specific files or glob patterns to review')
   .option('--file <file>', 'Analyze a single file')
   .option('-d, --directory <dir>', 'Working directory for git operations (use with --diff-with)')
@@ -163,12 +167,12 @@ Examples:
   $ codecritique analyze --directory src/components
   $ codecritique analyze --file src/utils/validation.ts
   $ codecritique analyze --files "src/**/*.tsx" "lib/*.js"
-  $ codecritique analyze -b main
+  $ codecritique analyze -b feature-branch
   $ codecritique analyze --doc "Our Eng Guidelines:./ENGINEERING_GUIDELINES.md" --file src/utils/validation.ts
   $ codecritique analyze --diff-with feature-branch -d /path/to/repo
   $ codecritique analyze --output json > review-results.json
   $ codecritique analyze --track-feedback --feedback-path ./feedback-artifacts --file src/utils/validation.ts
-  $ codecritique analyze --track-feedback --feedback-threshold 0.8 -b main
+  $ codecritique analyze --track-feedback --feedback-threshold 0.8 -b feature-branch
   $ codecritique embeddings:generate --directory src
   $ codecritique embeddings:generate --exclude "**/*.test.js" "**/*.spec.js"
   $ codecritique embeddings:generate --exclude-file .embedignore
@@ -357,23 +361,26 @@ async function runCodeReview(options) {
     diagnosticLog(chalk.bold.blue('AI Code Review (RAG Approach) - Starting analysis...'));
 
     // Determine the review mode based on options
-    // Only support: single file, specific files, or diff with branch
+    // Only support: single file, specific files, or target-branch diff review
     if (options.diffWith) {
+      const targetBranch = options.diffWith;
       // Use directory option as working directory for git commands if specified
       const gitWorkingDir = options.directory ? path.resolve(options.directory) : process.cwd();
-      const changedFiles = getChangedFiles(options.diffWith, gitWorkingDir);
+      const { changedFiles, baseBranch } = getChangedFiles(targetBranch, gitWorkingDir, options.base);
       if (changedFiles.length === 0) {
-        const message = `No changed files found compared to branch '${options.diffWith}'. Exiting.`;
+        const message = `No changed files found in target branch '${targetBranch}' compared to its detected parent branch. Exiting.`;
         diagnosticLog(chalk.yellow(message));
         await emitEmptyReviewOutputIfNeeded(options, { success: true, results: [], message });
         return;
       }
-      operationDescription = `${changedFiles.length} files changed vs ${options.diffWith}`;
-      // Add the actual branch name to reviewOptions
+      operationDescription = `${changedFiles.length} files changed in target branch ${targetBranch}`;
+      // Add the actual branch name to reviewOptions. Pass the already-detected
+      // parent branch so the review pipeline doesn't re-run parent detection.
       const enhancedReviewOptions = {
         ...reviewOptions,
-        actualBranch: options.diffWith,
-        diffWith: options.diffWith,
+        actualBranch: targetBranch,
+        diffWith: targetBranch,
+        baseBranch,
       };
       reviewTask = reviewPullRequest(changedFiles, enhancedReviewOptions);
     }
@@ -400,7 +407,7 @@ async function runCodeReview(options) {
       console.error(chalk.red('Error: You must specify one of the following:'));
       console.error(chalk.yellow('  --file <file>                    Analyze a single file'));
       console.error(chalk.yellow('  --files <files...>               Analyze specific files or glob patterns'));
-      console.error(chalk.yellow('  -b, --diff-with <branch>         Analyze files changed in a branch'));
+      console.error(chalk.yellow('  -b, --diff-with <branch>         Review a target branch against its auto-detected parent branch'));
       console.error(chalk.gray('\nOptional:'));
       console.error(chalk.gray('  -d, --directory <dir>            Working directory (for git operations with --diff-with)'));
       console.error(chalk.gray('\nExamples:'));
@@ -973,24 +980,36 @@ async function expandFilePatterns(patterns, baseDir = process.cwd()) {
 }
 
 /**
- * Get list of files changed in a branch compared to the base branch (main/master).
- * This shows what changes the specified branch has compared to the base.
+ * Get list of files changed in the target branch compared to its base branch.
+ * The supplied branch is the branch being reviewed, not the base branch.
  *
- * @param {string} branch - Branch to analyze (the feature/target branch)
+ * When `explicitBase` is given (e.g. the authoritative PR base ref in CI) it is
+ * used directly. Otherwise the parent is auto-detected (see findParentBranch),
+ * so stacked PRs are diffed against the branch they were forked from rather than
+ * always against main/master/develop.
+ *
+ * @param {string} targetBranch - Branch to analyze (the feature/target branch)
  * @param {string} workingDir - Directory to run git commands in (optional, defaults to cwd)
- * @returns {Array<string>} Array of changed file paths relative to git root
+ * @param {string} [explicitBase] - Base branch to diff against, overriding auto-detection
+ * @returns {{ changedFiles: Array<string>, baseBranch: string|null }} Changed file paths
+ *   (absolute) and the base branch they were diffed against (null on error).
  */
-function getChangedFiles(branch, workingDir = process.cwd()) {
+function getChangedFiles(targetBranch, workingDir = process.cwd(), explicitBase = undefined) {
   try {
     // Get git root directory
     const gitRoot = execSync('git rev-parse --show-toplevel', { cwd: workingDir }).toString().trim();
     diagnosticLog(chalk.gray(`Git repository: ${gitRoot}`));
 
-    // Ensure the branch exists locally (fetch if needed)
-    ensureBranchExists(branch, workingDir);
+    // Ensure the target branch exists locally (fetch if needed)
+    ensureBranchExists(targetBranch, workingDir);
 
-    // Find the base branch (main/master)
-    const baseBranch = findBaseBranch(workingDir);
+    // Use the explicitly provided base (authoritative, e.g. the PR base ref in CI)
+    // when given; otherwise detect the parent branch the target was forked from
+    // (main/master/develop, or another feature branch in stacked-PR workflows).
+    const baseBranch = explicitBase || findParentBranch(targetBranch, workingDir);
+    if (explicitBase) {
+      diagnosticLog(chalk.gray(`Using explicit base branch '${baseBranch}' (auto-detection skipped)`));
+    }
 
     // Ensure the base branch exists locally as well (crucial for diff operations)
     try {
@@ -1001,12 +1020,13 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
       // Continue with the original baseBranch name, it might work with remote refs
     }
 
-    diagnosticLog(chalk.gray(`Comparing ${branch} against ${baseBranch}...`));
+    diagnosticLog(chalk.gray(`Reviewing target branch '${targetBranch}' against base branch '${baseBranch}'...`));
 
-    // Use three-dot notation to get changes in branch compared to base
-    // This shows commits that are in 'branch' but not in 'baseBranch'
+    // Use three-dot notation to get changes in the target branch compared to the base.
     // By adding --diff-filter=d, we exclude deleted files from the list.
-    const gitOutput = execGitSafe('git diff', ['--name-only', '--diff-filter=d', `${baseBranch}...${branch}`], { cwd: gitRoot }).toString();
+    const gitOutput = execGitSafe('git diff', ['--name-only', '--diff-filter=d', `${baseBranch}...${targetBranch}`], {
+      cwd: gitRoot,
+    }).toString();
 
     // Split, filter empty lines, resolve paths, and check existence
     const changedFiles = gitOutput
@@ -1015,14 +1035,14 @@ function getChangedFiles(branch, workingDir = process.cwd()) {
       .map((file) => path.resolve(gitRoot, file)); // Get absolute path
 
     if (changedFiles.length > 0) {
-      diagnosticLog(chalk.gray(`Found ${changedFiles.length} changed files in ${branch} vs ${baseBranch}`));
+      diagnosticLog(chalk.gray(`Found ${changedFiles.length} changed files in target branch '${targetBranch}' vs base '${baseBranch}'`));
     }
 
-    return changedFiles;
+    return { changedFiles, baseBranch };
   }
   catch (err) {
     console.error(chalk.red('Error getting git diff:'), err.message);
-    return [];
+    return { changedFiles: [], baseBranch: null };
   }
 }
 

--- a/src/rag-review.js
+++ b/src/rag-review.js
@@ -10,7 +10,7 @@ import path from 'path';
 import chalk from 'chalk';
 import { runAnalysis, gatherUnifiedContextForPR } from './rag-analyzer.js';
 import { shouldProcessFile } from './utils/file-validation.js';
-import { findBaseBranch, getChangedLinesInfo, getFileContentFromGit } from './utils/git.js';
+import { ensureBranchExists, findParentBranch, getChangedLinesInfo, getFileContentFromGit } from './utils/git.js';
 import { detectFileType, detectLanguageFromExtension } from './utils/language-detection.js';
 import { verboseLog } from './utils/logging.js';
 import { shouldChunkPR, chunkPRFiles, combineChunkResults } from './utils/pr-chunking.js';
@@ -209,8 +209,9 @@ async function reviewPullRequest(changedFilePaths, options = {}) {
  * @param {boolean} [options.verbose=false] - Enable verbose progress logging
  * @param {number} [options.concurrency=3] - Maximum number of fallback per-file reviews to run in parallel
  * @param {string} [options.directory] - Working directory for git operations
- * @param {string} [options.diffWith='HEAD'] - Branch or ref to compare against
+ * @param {string} [options.diffWith='HEAD'] - Target branch or ref being reviewed against the detected base branch
  * @param {string} [options.actualBranch] - Actual target branch used for content retrieval
+ * @param {string} [options.baseBranch] - Pre-detected parent/base branch to diff against; detected here if omitted
  * @param {boolean} [options.skipChunking=false] - Skip PR chunking, used internally for chunk review recursion
  * @returns {Promise<Object>} Aggregated review results
  */
@@ -221,11 +222,26 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
 
     // Step 1: Get the base branch and collect diff info for all files in the PR
     const workingDir = options.directory ? path.resolve(options.directory) : process.cwd();
-    const baseBranch = findBaseBranch(workingDir);
     const targetBranch = options.diffWith || 'HEAD'; // The feature branch being reviewed
 
     // Get the actual branch name from options passed from index.js
     const actualTargetBranch = options.actualBranch || targetBranch;
+
+    // Prefer the parent branch already detected (and materialized locally) by the
+    // caller to avoid re-running the O(branches) detection. Only detect here when
+    // this function is invoked directly without a pre-detected base.
+    let baseBranch = options.baseBranch;
+    if (!baseBranch) {
+      baseBranch = findParentBranch(actualTargetBranch, workingDir);
+      // Detection may return a branch that exists only on the remote; ensure it
+      // resolves locally before it is used for diffing.
+      try {
+        ensureBranchExists(baseBranch, workingDir);
+      }
+      catch (error) {
+        verboseLog(verbose, chalk.yellow(`Could not ensure base branch '${baseBranch}' exists locally: ${error.message}`));
+      }
+    }
 
     verboseLog(verbose, chalk.gray(`Base branch: ${baseBranch}, Target branch: ${targetBranch}`));
 
@@ -319,7 +335,9 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
     verboseLog(
       verbose,
       chalk.green(
-        `De-duplicated context: ${deduplicatedCodeExamples.length} code examples, ${deduplicatedGuidelines.length} guidelines, ${deduplicatedPRComments.length} PR comments, ${deduplicatedCustomDocChunks.length} custom doc chunks`
+        `De-duplicated context: ${deduplicatedCodeExamples.length} code examples, ${deduplicatedGuidelines.length} guidelines, ${
+          deduplicatedPRComments.length
+        } PR comments, ${deduplicatedCustomDocChunks.length} custom doc chunks`
       )
     );
 

--- a/src/rag-review.test.js
+++ b/src/rag-review.test.js
@@ -1,7 +1,7 @@
 import { runAnalysis, gatherUnifiedContextForPR } from './rag-analyzer.js';
 import { reviewFile, reviewFiles, reviewPullRequest } from './rag-review.js';
 import { shouldProcessFile } from './utils/file-validation.js';
-import { getChangedLinesInfo, getFileContentFromGit } from './utils/git.js';
+import { ensureBranchExists, findParentBranch, getChangedLinesInfo, getFileContentFromGit } from './utils/git.js';
 import { shouldChunkPR, chunkPRFiles, combineChunkResults } from './utils/pr-chunking.js';
 
 vi.mock('./rag-analyzer.js', () => ({
@@ -19,7 +19,8 @@ vi.mock('./utils/file-validation.js', () => ({
 }));
 
 vi.mock('./utils/git.js', () => ({
-  findBaseBranch: vi.fn().mockReturnValue('main'),
+  ensureBranchExists: vi.fn(),
+  findParentBranch: vi.fn().mockReturnValue('main'),
   getChangedLinesInfo: vi.fn().mockReturnValue({
     hasChanges: true,
     addedLines: [1, 2, 3],
@@ -208,6 +209,38 @@ describe('rag-review', () => {
 
       expect(result.success).toBe(true);
       expect(result.results).toEqual([]);
+    });
+
+    it('should use a pre-detected baseBranch without re-running parent detection', async () => {
+      findParentBranch.mockClear();
+      getChangedLinesInfo.mockClear();
+      runAnalysis.mockResolvedValue({
+        success: true,
+        results: { issues: [], crossFileIssues: [], summary: 'OK' },
+      });
+
+      await reviewPullRequest(['/src/file.js'], { actualBranch: 'feature-B', baseBranch: 'feature-A' });
+
+      // Detection is skipped when the caller supplies the base branch...
+      expect(findParentBranch).not.toHaveBeenCalled();
+      // ...and the supplied base is what the per-file diff is computed against.
+      expect(getChangedLinesInfo).toHaveBeenCalledWith('/src/file.js', 'feature-A', 'feature-B', expect.any(String));
+    });
+
+    it('should detect and ensure the parent branch when none is supplied', async () => {
+      findParentBranch.mockClear();
+      ensureBranchExists.mockClear();
+      findParentBranch.mockReturnValue('main');
+      runAnalysis.mockResolvedValue({
+        success: true,
+        results: { issues: [], crossFileIssues: [], summary: 'OK' },
+      });
+
+      await reviewPullRequest(['/src/file.js'], { actualBranch: 'feature-X' });
+
+      expect(findParentBranch).toHaveBeenCalledWith('feature-X', expect.any(String));
+      // A detected (possibly remote-only) base must be materialized locally before diffing.
+      expect(ensureBranchExists).toHaveBeenCalledWith('main', expect.any(String));
     });
 
     it('should skip files based on exclusion rules', async () => {

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -117,6 +117,160 @@ export function findBaseBranch(workingDir = process.cwd()) {
 }
 
 /**
+ * Resolve a usable git ref for a branch, preferring a local ref and falling
+ * back to the origin remote ref. Returns null if neither resolves.
+ *
+ * @param {string} branchName - Short branch name (e.g. 'feature-x')
+ * @param {string} workingDir - Directory to run git commands in
+ * @returns {string|null} A resolvable ref ('feature-x' or 'origin/feature-x'), or null
+ */
+function resolveBranchRef(branchName, workingDir = process.cwd()) {
+  // HEAD (including detached HEAD) resolves directly as a rev; never fall through
+  // to refs/remotes/origin/HEAD, which would point at the remote's default branch.
+  if (branchName === 'HEAD') {
+    return 'HEAD';
+  }
+  if (checkBranchExists(branchName, workingDir)) {
+    return branchName;
+  }
+  try {
+    execGitSafe('git show-ref', ['--verify', '--quiet', `refs/remotes/origin/${branchName}`], { cwd: workingDir });
+    return `origin/${branchName}`;
+  }
+  catch {
+    return null;
+  }
+}
+
+/**
+ * List candidate branches (local heads + origin remotes), mapping each short
+ * name to a resolvable ref. Local refs are preferred over remote ones, and
+ * 'origin/HEAD' is skipped.
+ *
+ * @param {string} workingDir - Directory to run git commands in
+ * @returns {Map<string, string>} short branch name -> resolvable ref
+ */
+function listCandidateBranches(workingDir = process.cwd()) {
+  const output = execGitSafe('git for-each-ref', ['--format=%(refname:short)', 'refs/heads/', 'refs/remotes/origin/'], {
+    cwd: workingDir,
+  }).toString();
+
+  const candidates = new Map();
+  for (const raw of output.split('\n')) {
+    const refShort = raw.trim();
+    if (!refShort) {
+      continue;
+    }
+
+    const isRemote = refShort.startsWith('origin/');
+    const shortName = isRemote ? refShort.slice('origin/'.length) : refShort;
+    if (shortName === 'HEAD') {
+      continue;
+    }
+
+    // Prefer a local ref over the remote one for the same short name.
+    if (!candidates.has(shortName) || !isRemote) {
+      candidates.set(shortName, refShort);
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Detect the parent branch a target branch was forked from.
+ *
+ * Git does not record branch parentage, so this infers it heuristically. A valid
+ * base must be an *ancestor* of the target (the target contains all of its
+ * commits); among those ancestors, the one the target is fewest commits ahead of
+ * is the nearest ancestor and therefore the most likely parent. This correctly
+ * resolves stacked PRs (e.g. main -> feature-A -> feature-B detects feature-A as
+ * feature-B's parent) while still selecting main/master/develop for ordinary
+ * feature branches.
+ *
+ * The ancestor requirement is what makes the heuristic safe: branches that
+ * forked *from* the target (e.g. a child branch off the middle of the target's
+ * history) are not ancestors of the target, so they are excluded and can never
+ * win on target-side distance alone and silently produce a wrong diff. Branches
+ * with unrelated history are likewise skipped. When ties occur, a standard base
+ * branch (main/master/develop) is preferred for stability. If no ancestor parent
+ * can be inferred, it falls back to {@link findBaseBranch}.
+ *
+ * Deliberate trade-off (do not "fix" by ranking on target-side distance alone):
+ * if the real parent has advanced beyond the point where the target forked (it
+ * has commits the target lacks), it is no longer an ancestor and is skipped;
+ * detection then falls back to the nearest stable ancestor (e.g. main). That
+ * over-includes the parent's extra commits in the review but never omits any of
+ * the target's own commits — the safe direction. Recovering the advanced parent
+ * is impossible from topology alone (an advanced parent and a branch forked from
+ * the middle of the target are indistinguishable in the commit graph; only the
+ * target's local creation reflog can tell them apart, and that is absent in CI),
+ * so this case is intentionally left to fall back rather than risk silently
+ * hiding the target's commits.
+ *
+ * @param {string} targetBranch - The branch being reviewed
+ * @param {string} workingDir - Directory to run git commands in (optional, defaults to cwd)
+ * @returns {string} The detected parent/base branch name
+ *
+ * @example
+ * const parent = findParentBranch('feature-B');
+ * // -> 'feature-A' when feature-B was stacked on feature-A
+ */
+export function findParentBranch(targetBranch, workingDir = process.cwd()) {
+  try {
+    const targetRef = resolveBranchRef(targetBranch, workingDir) ?? targetBranch;
+
+    const preferred = ['main', 'master', 'develop'];
+    let best = null; // { name, ahead, isPreferred }
+
+    for (const [shortName, ref] of listCandidateBranches(workingDir)) {
+      if (shortName === targetBranch) {
+        continue;
+      }
+
+      // A valid base must be an ancestor of the target. This excludes branches
+      // that forked from the target (which have commits the target lacks) and
+      // branches with unrelated history -- either would otherwise be picked on
+      // target-side distance alone and hide commits from the diff.
+      try {
+        execGitSafe('git merge-base', ['--is-ancestor', ref, targetRef], { cwd: workingDir });
+      }
+      catch {
+        continue; // Not an ancestor of the target: not a candidate parent.
+      }
+
+      // Commits the target has beyond this ancestor; the nearest ancestor
+      // (fewest such commits) is the most likely parent.
+      const ahead = parseInt(
+        execGitSafe('git rev-list', ['--count', `${ref}..${targetRef}`], { cwd: workingDir })
+          .toString()
+          .trim(),
+        10
+      );
+      if (!Number.isFinite(ahead) || ahead === 0) {
+        continue; // Even with the target (same tip): not a parent.
+      }
+
+      const isPreferred = preferred.includes(shortName);
+      if (best === null || ahead < best.ahead || (ahead === best.ahead && isPreferred && !best.isPreferred)) {
+        best = { name: shortName, ahead, isPreferred };
+      }
+    }
+
+    if (best) {
+      verboseLog({}, chalk.gray(`Detected parent branch '${best.name}' for '${targetBranch}' (${best.ahead} commit(s) ahead)`));
+      return best.name;
+    }
+  }
+  catch (error) {
+    verboseLog({}, chalk.yellow(`Parent branch detection failed (${error.message}); falling back to base branch detection`));
+  }
+
+  // Nothing closer found: fall back to the standard base branch heuristic.
+  return findBaseBranch(workingDir);
+}
+
+/**
  * Get git diff content for a specific file between two branches/commits
  *
  * @param {string} filePath - Path to the file

--- a/src/utils/git.test.js
+++ b/src/utils/git.test.js
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import * as command from './command.js';
-import { ensureBranchExists, findBaseBranch, getChangedLinesInfo, getFileContentFromGit } from './git.js';
+import { ensureBranchExists, findBaseBranch, findParentBranch, getChangedLinesInfo, getFileContentFromGit } from './git.js';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
@@ -85,6 +85,172 @@ describe('findBaseBranch', () => {
     });
 
     findBaseBranch('/custom/path');
+  });
+});
+
+describe('findParentBranch', () => {
+  beforeEach(() => {
+    mockConsoleSelective('warn');
+  });
+
+  it('should detect the nearest ancestor branch in a stacked-PR setup', () => {
+    // main -> feature-A -> feature-B; both are ancestors of feature-B.
+    command.execGitSafe.mockImplementation((cmd, args) => {
+      if (cmd === 'git show-ref') {
+        if (args.includes('refs/heads/feature-B')) {
+          return ''; // target exists locally
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'feature-A\nfeature-B\nmain\n';
+      }
+      if (cmd === 'git merge-base') {
+        return ''; // --is-ancestor succeeds: both feature-A and main are ancestors
+      }
+      if (cmd === 'git rev-list') {
+        if (args.includes('feature-A..feature-B')) {
+          return '2';
+        }
+        if (args.includes('main..feature-B')) {
+          return '4';
+        }
+      }
+      throw new Error(`unexpected call: ${cmd} ${args}`);
+    });
+
+    // feature-A is the nearer ancestor (2 commits behind vs main's 4) -> parent is feature-A
+    expect(findParentBranch('feature-B')).toBe('feature-A');
+  });
+
+  it('should not pick a branch forked from the middle of the target (child outranking real parent)', () => {
+    // main -> target(commit 1) -> child forks -> target(commit 2).
+    // 'child-from-middle' is NOT an ancestor of target, so it must be excluded
+    // even though the target is only 1 commit ahead of their merge-base.
+    const revListCalls = [];
+    command.execGitSafe.mockImplementation((cmd, args) => {
+      if (cmd === 'git show-ref') {
+        if (args.includes('refs/heads/target')) {
+          return '';
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'child-from-middle\nmain\ntarget\n';
+      }
+      if (cmd === 'git merge-base') {
+        // --is-ancestor: child is not an ancestor of target; main is.
+        if (args.includes('child-from-middle')) {
+          throw new Error('not an ancestor');
+        }
+        if (args.includes('main')) {
+          return '';
+        }
+      }
+      if (cmd === 'git rev-list') {
+        revListCalls.push(args.join(' '));
+        if (args.includes('main..target')) {
+          return '2';
+        }
+      }
+      throw new Error(`unexpected call: ${cmd} ${args}`);
+    });
+
+    expect(findParentBranch('target')).toBe('main');
+    // The child branch is rejected before any distance is computed for it.
+    expect(revListCalls.some((c) => c.includes('child-from-middle'))).toBe(false);
+  });
+
+  it('should skip a descendant branch that fully contains the target', () => {
+    // 'downstream' contains the target's commits, so it is not an ancestor of the target.
+    command.execGitSafe.mockImplementation((cmd, args) => {
+      if (cmd === 'git show-ref') {
+        if (args.includes('refs/heads/feature-B')) {
+          return '';
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'downstream\nfeature-B\nmain\n';
+      }
+      if (cmd === 'git merge-base') {
+        if (args.includes('downstream')) {
+          throw new Error('not an ancestor'); // target does not contain downstream's commits
+        }
+        if (args.includes('main')) {
+          return '';
+        }
+      }
+      if (cmd === 'git rev-list') {
+        return '5';
+      }
+      throw new Error(`unexpected call: ${cmd} ${args}`);
+    });
+
+    expect(findParentBranch('feature-B')).toBe('main');
+  });
+
+  it('should prefer a standard base branch when distances tie', () => {
+    // feature-Y and main are both ancestors of feature-X at the same distance.
+    command.execGitSafe.mockImplementation((cmd, args) => {
+      if (cmd === 'git show-ref') {
+        if (args.includes('refs/heads/feature-X')) {
+          return '';
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'feature-X\nfeature-Y\nmain\n';
+      }
+      if (cmd === 'git merge-base') {
+        return ''; // both are ancestors
+      }
+      if (cmd === 'git rev-list') {
+        return '3'; // identical distance
+      }
+      throw new Error(`unexpected call: ${cmd} ${args}`);
+    });
+
+    expect(findParentBranch('feature-X')).toBe('main');
+  });
+
+  it('should fall back to findBaseBranch when no ancestor parent can be inferred', () => {
+    command.execGitSafe.mockImplementation((cmd, args) => {
+      if (cmd === 'git show-ref') {
+        // target resolves; base branch detection finds 'main'
+        if (args.includes('refs/heads/feature-solo')) {
+          return '';
+        }
+        if (args.includes('refs/heads/main')) {
+          return '';
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'feature-solo\n'; // only the target exists -> no candidates
+      }
+      throw new Error(`unexpected call: ${cmd} ${args}`);
+    });
+
+    expect(findParentBranch('feature-solo')).toBe('main');
+  });
+
+  it('should use provided working directory', () => {
+    command.execGitSafe.mockImplementation((cmd, args, options) => {
+      expect(options.cwd).toBe('/custom/path');
+      if (cmd === 'git show-ref') {
+        if (args.includes('refs/heads/feature-X')) {
+          return '';
+        }
+        throw new Error('not found');
+      }
+      if (cmd === 'git for-each-ref') {
+        return 'feature-X\n';
+      }
+      return '';
+    });
+
+    findParentBranch('feature-X', '/custom/path');
   });
 });
 


### PR DESCRIPTION
This PR fixes the branch-diff semantics for CLI and GitHub Action PR reviews.

- Clarifies that `-b, --diff-with` is the target branch being reviewed, not the base branch.
- Adds safe parent-branch detection for local stacked branch reviews, including protection against child branches being mistaken for parents.
- Adds `--base` so callers with an authoritative base ref can bypass inference and diff directly against that branch.
- Updates the PR review action to fetch the PR head/base refs, deepen shallow history only as needed, and pass `github.base_ref` through as `--base`.
- Keeps file discovery and per-file line diffs aligned on the same resolved base branch.
- Updates docs and examples for target-branch review, explicit base usage, and GitHub Actions setup.