### PR TITLE
Bound project analyzer content scans

### DIFF
--- a/src/project-analyzer.js
+++ b/src/project-analyzer.js
@@ -16,6 +16,8 @@ import { isDocumentationFile, isTestFile } from './utils/file-validation.js';
 import { verboseLog } from './utils/logging.js';
 import { escapeSqlString } from './utils/string-utils.js';
 
+const TERM_SEARCH_CONTENT_CANDIDATE_LIMIT = 500;
+
 // Consolidated file classification configuration
 const FILE_PATTERNS = {
   config: {
@@ -383,14 +385,18 @@ export class ProjectAnalyzer {
       // Unified query function
       const queryFiles = async (config) => {
         try {
-          let query = table.query().select(['path', 'name', 'content', 'type', 'language']);
-
           if (config.whereClause) {
-            query = query.where(`${projectPathFilter} AND (${config.whereClause})`);
+            return await table
+              .query()
+              .select(['path', 'name', 'content', 'type', 'language'])
+              .where(`${projectPathFilter} AND (${config.whereClause})`)
+              .limit(config.limit || 30)
+              .toArray();
           }
           else if (config.terms) {
-            // For term-based searches, query ALL files and sort by depth to prioritize shallow config files
-            const allFiles = await table.query().select(['path', 'name', 'content', 'type', 'language']).where(projectPathFilter).toArray(); // NO LIMIT - get all files
+            // For term-based searches, query metadata first and only fetch content for
+            // the shallow candidate set used for matching.
+            const allFiles = await table.query().select(['path', 'name', 'type', 'language']).where(projectPathFilter).toArray();
 
             // Sort by path depth (shorter paths first) to prioritize config files
             allFiles.sort((a, b) => {
@@ -400,24 +406,54 @@ export class ProjectAnalyzer {
             });
 
             // Take only the first 500 after sorting to ensure we have shallow files
-            const sortedFiles = allFiles.slice(0, 500);
+            const sortedFiles = allFiles.slice(0, TERM_SEARCH_CONTENT_CANDIDATE_LIMIT);
+            if (sortedFiles.length === 0) {
+              return [];
+            }
 
-            return sortedFiles.filter((result) => {
-              const content = (result.content || '').toLowerCase();
-              const pathName = (result.path || '').toLowerCase();
-              const name = (result.name || '').toLowerCase();
-              const matches = config.terms.some(
-                (term) => content.includes(term.toLowerCase()) || pathName.includes(term.toLowerCase()) || name.includes(term.toLowerCase())
-              );
+            const candidatePaths = sortedFiles.map((file) => file.path).filter(Boolean);
+            const contentByPath = new Map();
+            if (candidatePaths.length > 0) {
+              const pathList = candidatePaths.map((candidatePath) => `'${escapeSqlString(candidatePath)}'`).join(', ');
+              const contentResults = await table
+                .query()
+                .select(['path', 'content'])
+                .where(`${projectPathFilter} AND path IN (${pathList})`)
+                .limit(TERM_SEARCH_CONTENT_CANDIDATE_LIMIT)
+                .toArray();
 
-              return matches;
-            });
+              for (const result of contentResults) {
+                contentByPath.set(result.path, result.content || '');
+              }
+            }
+
+            return sortedFiles
+              .filter((result) => {
+                const content = (contentByPath.get(result.path) || '').toLowerCase();
+                const pathName = (result.path || '').toLowerCase();
+                const name = (result.name || '').toLowerCase();
+                const matches = config.terms.some(
+                  (term) =>
+                    content.includes(term.toLowerCase()) || pathName.includes(term.toLowerCase()) || name.includes(term.toLowerCase())
+                );
+
+                return matches;
+              })
+              .map((result) => {
+                return {
+                  ...result,
+                  content: contentByPath.get(result.path) || '',
+                };
+              });
           }
           else {
-            query = query.where(projectPathFilter);
+            return await table
+              .query()
+              .select(['path', 'name', 'content', 'type', 'language'])
+              .where(projectPathFilter)
+              .limit(config.limit || 30)
+              .toArray();
           }
-
-          return await query.limit(config.limit || 30).toArray();
         }
         catch (error) {
           verboseLog({}, chalk.yellow(`     ⚠️ Query failed for ${config.category}: ${error.message}`));

--- a/src/project-analyzer.test.js
+++ b/src/project-analyzer.test.js
@@ -410,6 +410,79 @@ describe('ProjectAnalyzer', () => {
       expect(queryChain.where).toHaveBeenCalledWith(expect.stringContaining("/mock/we''re/project"));
     });
 
+    it('should bound content reads for term-based key file searches', async () => {
+      const queryCalls = [];
+      mockTable.query.mockImplementation(() => {
+        const call = {
+          select: [],
+          where: [],
+          limit: [],
+        };
+        queryCalls.push(call);
+
+        const chain = {
+          select: vi.fn((columns) => {
+            call.select.push(columns);
+            return chain;
+          }),
+          where: vi.fn((clause) => {
+            call.where.push(clause);
+            return chain;
+          }),
+          limit: vi.fn((limit) => {
+            call.limit.push(limit);
+            return chain;
+          }),
+          toArray: vi.fn(async () => {
+            const selectedColumns = call.select[0] || [];
+            if (selectedColumns.includes('content')) {
+              return [
+                {
+                  path: 'package.json',
+                  name: 'package.json',
+                  content: '{"name": "test-project"}',
+                  type: 'json',
+                  language: 'json',
+                },
+              ];
+            }
+
+            return [
+              {
+                path: 'package.json',
+                name: 'package.json',
+                type: 'json',
+                language: 'json',
+              },
+            ];
+          }),
+        };
+
+        return chain;
+      });
+
+      const result = await analyzer.mineKeyFilesFromEmbeddings(mockProjectPath);
+
+      expect(result.some((file) => file.path === 'package.json')).toBe(true);
+      expect(
+        queryCalls.some((call) => {
+          const selectedColumns = call.select[0] || [];
+          return selectedColumns.includes('content') && call.where[0] === "project_path = '/mock/project'" && call.limit.length === 0;
+        })
+      ).toBe(false);
+      expect(
+        queryCalls.some((call) => {
+          const selectedColumns = call.select[0] || [];
+          return (
+            selectedColumns.includes('path') &&
+            selectedColumns.includes('name') &&
+            !selectedColumns.includes('content') &&
+            call.where[0] === "project_path = '/mock/project'"
+          );
+        })
+      ).toBe(true);
+    });
+
     it('should handle table optimization errors gracefully', async () => {
       mockTable.optimize.mockRejectedValue(new Error('legacy format'));
       mockTable.query().toArray.mockResolvedValue([]);


### PR DESCRIPTION
This PR keeps project key-file discovery from loading every indexed file body during term-based searches.

- Changes term searches to scan only file metadata for the broad project query.
- Preserves the existing shallow-file priority by sorting paths by depth before selecting candidates.
- Fetches content only for the bounded shallow candidate set used for matching.
- Adds regression coverage to prevent reintroducing an unbounded content scan for project-wide term searches.