### PR TITLE
Cache stable project context

### DIFF
--- a/src/llm.js
+++ b/src/llm.js
@@ -44,6 +44,44 @@ const DEFAULT_MODEL = 'claude-sonnet-4-5';
 // Maximum tokens for response
 const MAX_TOKENS = 4096;
 
+const MAX_CACHE_CONTROL_BLOCKS = 4;
+
+function normalizeSystemBlock(block, cacheControl) {
+  const normalizedBlock = typeof block === 'string' ? { type: 'text', text: block } : { type: 'text', ...block };
+
+  if (cacheControl) {
+    return {
+      ...normalizedBlock,
+      cache_control: normalizedBlock.cache_control || cacheControl,
+    };
+  }
+
+  return normalizedBlock;
+}
+
+function buildSystemContent(system, cachedSystemBlocks, cacheControl) {
+  if (!system && cachedSystemBlocks.length === 0) {
+    return 'You are an expert code reviewer with deep knowledge of software engineering principles, design patterns, and best practices.';
+  }
+
+  const systemBlocks = [];
+  const appendBlock = (block) => {
+    const cacheable = systemBlocks.filter((existingBlock) => existingBlock.cache_control).length < MAX_CACHE_CONTROL_BLOCKS;
+    systemBlocks.push(normalizeSystemBlock(block, cacheable ? cacheControl : null));
+  };
+
+  if (Array.isArray(system)) {
+    system.forEach(appendBlock);
+  }
+  else if (system) {
+    appendBlock(system);
+  }
+
+  cachedSystemBlocks.filter(Boolean).forEach(appendBlock);
+
+  return systemBlocks;
+}
+
 /**
  * Send a prompt to Claude and get a structured JSON response using tool calling.
  * Uses prompt caching for system prompts to reduce token costs.
@@ -51,12 +89,21 @@ const MAX_TOKENS = 4096;
  * @param {string} prompt - The prompt to send to Claude
  * @param {Object} options - Options for the request
  * @param {string} options.system - System prompt (will be cached for cost optimization)
+ * @param {Array<string|Object>} options.cachedSystemBlocks - Additional stable system blocks to cache when possible
  * @param {Object} options.jsonSchema - JSON schema for structured output
  * @param {string} options.cacheTtl - Cache TTL: '5m' (default, no extra cost) or '1h' (extended, extra cost for writes)
  * @returns {Promise<Object>} The response from Claude with structured data
  */
 async function sendPromptToClaude(prompt, options = {}) {
-  const { model = DEFAULT_MODEL, maxTokens = MAX_TOKENS, temperature = 0.7, system = '', jsonSchema = null, cacheTtl = '5m' } = options;
+  const {
+    model = DEFAULT_MODEL,
+    maxTokens = MAX_TOKENS,
+    temperature = 0.7,
+    system = '',
+    cachedSystemBlocks = [],
+    jsonSchema = null,
+    cacheTtl = '5m',
+  } = options;
 
   try {
     verboseLog(options, chalk.cyan('Sending prompt to Claude...'));
@@ -68,15 +115,7 @@ async function sendPromptToClaude(prompt, options = {}) {
     // TTL options: '5m' (default, no extra cost) or '1h' (extended, extra cost for cache writes)
     const cacheControl = cacheTtl === '1h' ? { type: 'ephemeral', ttl: '1h' } : { type: 'ephemeral' };
 
-    const systemContent = system
-      ? [
-          {
-            type: 'text',
-            text: system,
-            cache_control: cacheControl,
-          },
-        ]
-      : 'You are an expert code reviewer with deep knowledge of software engineering principles, design patterns, and best practices.';
+    const systemContent = buildSystemContent(system, cachedSystemBlocks, cacheControl);
 
     // Build base request parameters
     const requestParams = {

--- a/src/llm.test.js
+++ b/src/llm.test.js
@@ -241,6 +241,62 @@ describe('sendPromptToClaude', () => {
         })
       );
     });
+
+    it('should append additional cached system blocks', async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [{ type: 'text', text: 'Response' }],
+        model: 'claude-sonnet-4-5',
+        usage: {},
+      });
+
+      await sendPromptToClaude('Test', {
+        system: 'Base review rules',
+        cachedSystemBlocks: ['Custom project instructions', 'Project architecture context'],
+      });
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: [
+            {
+              type: 'text',
+              text: 'Base review rules',
+              cache_control: { type: 'ephemeral' },
+            },
+            {
+              type: 'text',
+              text: 'Custom project instructions',
+              cache_control: { type: 'ephemeral' },
+            },
+            {
+              type: 'text',
+              text: 'Project architecture context',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        })
+      );
+    });
+
+    it('should include extra system blocks without exceeding cache breakpoint limits', async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [{ type: 'text', text: 'Response' }],
+        model: 'claude-sonnet-4-5',
+        usage: {},
+      });
+
+      await sendPromptToClaude('Test', {
+        system: 'Base review rules',
+        cachedSystemBlocks: ['Block 1', 'Block 2', 'Block 3', 'Block 4'],
+      });
+
+      const request = mockMessagesCreate.mock.calls.at(-1)[0];
+      expect(request.system).toHaveLength(5);
+      expect(request.system.filter((block) => block.cache_control)).toHaveLength(4);
+      expect(request.system.at(-1)).toEqual({
+        type: 'text',
+        text: 'Block 4',
+      });
+    });
   });
 
   describe('message format', () => {

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -835,6 +835,30 @@ MARKDOWN FORMATTING IN DESCRIPTIONS AND SUGGESTIONS:
 Your response must start with { and end with } with no additional text.`;
 }
 
+function buildCachedProjectContextBlocks({ roleDefinition, customDocsSection, projectArchitectureSection }) {
+  const blocks = [];
+
+  if (roleDefinition?.trim()) {
+    blocks.push(`REVIEW ROLE AND PROJECT INSTRUCTIONS
+
+${roleDefinition}`);
+  }
+
+  if (customDocsSection?.trim() && !customDocsSection.includes('No custom instructions provided.')) {
+    blocks.push(`CUSTOM PROJECT INSTRUCTIONS
+
+${customDocsSection}`);
+  }
+
+  if (projectArchitectureSection?.trim()) {
+    blocks.push(`PROJECT ARCHITECTURE CONTEXT
+
+${projectArchitectureSection}`);
+  }
+
+  return blocks;
+}
+
 // LLM call function - sends prompt with cached system content for cost optimization
 async function sendPromptToLLM(promptConfig, llmOptions) {
   try {
@@ -946,12 +970,14 @@ async function sendPromptToLLM(promptConfig, llmOptions) {
     verboseLog(llmOptions, chalk.gray(`  Prompt config has systemPrompt: ${!!promptConfig.systemPrompt}`));
     verboseLog(llmOptions, chalk.gray(`  Prompt config has userPrompt: ${!!promptConfig.userPrompt}`));
     verboseLog(llmOptions, chalk.gray(`  System prompt length: ${promptConfig.systemPrompt?.length || 0} chars`));
+    verboseLog(llmOptions, chalk.gray(`  Cached system blocks: ${promptConfig.cachedSystemBlocks?.length || 0}`));
     verboseLog(llmOptions, chalk.gray(`  User prompt length: ${promptConfig.userPrompt?.length || 0} chars`));
 
     // Send prompt with system (cached) and user (dynamic) content
     const response = await llm.sendPromptToClaude(promptConfig.userPrompt, {
       ...llmOptions,
       system: promptConfig.systemPrompt,
+      cachedSystemBlocks: promptConfig.cachedSystemBlocks || [],
       jsonSchema: codeReviewSchema,
     });
 
@@ -1096,21 +1122,21 @@ ${addLineNumbers(file.content)}
 
   // Build the cached system prompt (contains all static rules)
   const systemPrompt = buildCachedSystemPrompt('code');
+  const cachedSystemBlocks = buildCachedProjectContextBlocks({
+    roleDefinition,
+    customDocsSection,
+    projectArchitectureSection,
+  });
 
   // Build the dynamic user prompt (contains all variable content)
   const userPrompt = finalizePrompt(`
 ## REVIEW TYPE: CODE FILE ANALYSIS
 
-${roleDefinition}
-
 ${reviewInstructions}
-
-${customDocsSection}
 
 ${fileSection}
 
-CONTEXT FROM PROJECT:
-${projectArchitectureSection}
+Use the cached project context, project architecture, and custom instructions when evaluating this file.
 
 CONTEXT A: EXPLICIT GUIDELINES FROM DOCUMENTATION
 ${formattedGuidelines}
@@ -1136,7 +1162,7 @@ Analyze the FILE TO REVIEW above using the 4-stage methodology:
 - If you analyzed something and found it's fine, simply don't include it in the output
 `);
 
-  return { systemPrompt, userPrompt };
+  return { systemPrompt, userPrompt, cachedSystemBlocks };
 }
 
 /**
@@ -1215,22 +1241,22 @@ ${addLineNumbers(file.content)}
 
   // Build the cached system prompt (contains all static rules)
   const systemPrompt = buildCachedSystemPrompt('test');
+  const cachedSystemBlocks = buildCachedProjectContextBlocks({
+    roleDefinition,
+    customDocsSection,
+    projectArchitectureSection,
+  });
 
   // Build the dynamic user prompt (contains all variable content)
   const userPrompt = finalizePrompt(`
 ## REVIEW TYPE: TEST FILE ANALYSIS
-
-${roleDefinition}
 
 ${reviewInstructions}
 
 ${fileSection}
 
 ## ANALYSIS CONTEXT
-${customDocsSection}
-
-CONTEXT FROM PROJECT:
-${projectArchitectureSection}
+Use the cached project context, project architecture, and custom instructions when evaluating this test file.
 
 CONTEXT A: TESTING GUIDELINES AND BEST PRACTICES
 ${formattedGuidelines}
@@ -1253,7 +1279,7 @@ Analyze the TEST FILE above using the 5-stage methodology:
 - If you analyzed something and found it's fine, simply don't include it in the output
 `);
 
-  return { systemPrompt, userPrompt };
+  return { systemPrompt, userPrompt, cachedSystemBlocks };
 }
 
 /**
@@ -1371,12 +1397,15 @@ For each file in this PR, you have access to:
 
   // Build the cached system prompt (contains all static rules)
   const systemPrompt = buildCachedSystemPrompt('pr');
+  const cachedSystemBlocks = buildCachedProjectContextBlocks({
+    roleDefinition,
+    customDocsSection,
+    projectArchitectureSection,
+  });
 
   // Build the dynamic user prompt (contains all variable content)
   const userPrompt = finalizePrompt(`
 ## REVIEW TYPE: HOLISTIC PR ANALYSIS
-
-${roleDefinition}
 
 ## PULL REQUEST OVERVIEW
 - **Total Files**: ${prFiles.length}
@@ -1384,7 +1413,7 @@ ${roleDefinition}
 - **Test Files**: ${prFiles.filter((f) => f.isTest).length}
 
 ## UNIFIED CONTEXT FROM PROJECT
-${projectArchitectureSection}
+Use the cached project context, project architecture, and custom instructions when evaluating this pull request.
 
 ### PROJECT CODE EXAMPLES
 ${formattedCodeExamples}
@@ -1397,9 +1426,6 @@ ${formattedPRComments}
 
 ## PR FILES WITH CHANGES
 ${formattedPRFiles}
-
-## CUSTOM INSTRUCTIONS
-${customDocsSection}
 
 ## YOUR TASK
 
@@ -1418,7 +1444,7 @@ Analyze ALL PR FILES above using the 5-stage methodology:
 - If you analyzed something and found it's fine, simply don't include it in the output
 `);
 
-  return { systemPrompt, userPrompt };
+  return { systemPrompt, userPrompt, cachedSystemBlocks };
 }
 
 /**

--- a/src/rag-analyzer.test.js
+++ b/src/rag-analyzer.test.js
@@ -772,7 +772,9 @@ describe('rag-analyzer', () => {
         customDocs: [{ content: 'Mandatory internal review rule', document_title: 'Internal Standards' }],
       });
 
-      expect(llm.sendPromptToClaude).toHaveBeenCalledWith(expect.stringContaining('Mandatory internal review rule'), expect.any(Object));
+      const [, options] = llm.sendPromptToClaude.mock.calls.at(-1);
+      expect(options.cachedSystemBlocks.join('\n')).toContain('Mandatory internal review rule');
+      expect(llm.sendPromptToClaude.mock.calls.at(-1)[0]).not.toContain('Mandatory internal review rule');
     });
 
     it('should log selected chunks when verbose', async () => {


### PR DESCRIPTION
This PR moves stable review context into additional cached Anthropic system blocks so multi-file reviews do not resend the same project-level material in every user prompt.

- Adds support for additional cached system blocks in the Claude request builder.
- Preserves Anthropic's four cache-control breakpoint limit while still sending any extra system text uncached.
- Moves role/project instructions, custom documents, and project architecture context out of the dynamic review prompt.
- Keeps file contents, diffs, retrieved examples, retrieved guideline snippets, PR history, and feedback context dynamic.
- Adds regression coverage for cache block construction and custom-doc prompt placement.