### PR TITLE
Batch stale embedding deletes

### DIFF
--- a/src/embeddings/database.js
+++ b/src/embeddings/database.js
@@ -40,6 +40,37 @@ const FILE_EMBEDDINGS_TABLE = TABLE_NAMES.FILE_EMBEDDINGS;
 const DOCUMENT_CHUNK_TABLE = TABLE_NAMES.DOCUMENT_CHUNK;
 const PR_COMMENTS_TABLE = TABLE_NAMES.PR_COMMENTS;
 const PROJECT_SUMMARIES_TABLE = TABLE_NAMES.PROJECT_SUMMARIES;
+const DELETE_BATCH_SIZE = 100;
+
+function buildIdInFilter(ids) {
+  return `id IN (${ids.map((id) => `'${escapeSqlString(id)}'`).join(', ')})`;
+}
+
+async function deleteRecordsById(table, records, warningMessage) {
+  let deletedCount = 0;
+
+  for (let start = 0; start < records.length; start += DELETE_BATCH_SIZE) {
+    const batch = records.slice(start, start + DELETE_BATCH_SIZE);
+
+    try {
+      await table.delete(buildIdInFilter(batch.map((record) => record.id)));
+      deletedCount += batch.length;
+    }
+    catch {
+      for (const record of batch) {
+        try {
+          await table.delete(`id = '${escapeSqlString(record.id)}'`);
+          deletedCount++;
+        }
+        catch (deleteError) {
+          console.warn(chalk.yellow(warningMessage(record, deleteError)));
+        }
+      }
+    }
+  }
+
+  return deletedCount;
+}
 
 // ============================================================================
 // DATABASE MANAGER CLASS
@@ -620,9 +651,10 @@ export class DatabaseManager {
     const livePathSet = new Set(Array.from(livePaths));
     const records = await table
       .query()
+      .select(['id', 'path', 'type'])
       .where(`project_path = '${escapeSqlString(resolvedProjectPath)}'`)
       .toArray();
-    let deletedCount = 0;
+    const recordsToDelete = [];
 
     for (const record of records) {
       if (record.type === 'directory-structure') {
@@ -633,16 +665,14 @@ export class DatabaseManager {
         continue;
       }
 
-      try {
-        await table.delete(`id = '${escapeSqlString(record.id)}'`);
-        deletedCount++;
-      }
-      catch (deleteError) {
-        console.warn(chalk.yellow(`Warning: Could not prune file embedding ${record.id}: ${deleteError.message}`));
-      }
+      recordsToDelete.push(record);
     }
 
-    return deletedCount;
+    return await deleteRecordsById(
+      table,
+      recordsToDelete,
+      (record, deleteError) => `Warning: Could not prune file embedding ${record.id}: ${deleteError.message}`
+    );
   }
 
   /**

--- a/src/embeddings/database.test.js
+++ b/src/embeddings/database.test.js
@@ -29,7 +29,9 @@ const createMockTable = (overrides = {}) => ({
   countRows: vi.fn().mockResolvedValue(50),
   createIndex: vi.fn().mockResolvedValue(undefined),
   schema: { fields: [{ name: 'project_path' }] },
-  query: vi.fn().mockReturnValue({ where: vi.fn().mockReturnThis(), toArray: vi.fn().mockResolvedValue([]) }),
+  query: vi
+    .fn()
+    .mockReturnValue({ select: vi.fn().mockReturnThis(), where: vi.fn().mockReturnThis(), toArray: vi.fn().mockResolvedValue([]) }),
   add: vi.fn().mockResolvedValue(undefined),
   addColumns: vi.fn().mockResolvedValue(undefined),
   delete: vi.fn().mockResolvedValue(undefined),
@@ -394,17 +396,22 @@ describe('DatabaseManager', () => {
   describe('prune project embeddings', () => {
     it('should prune stale file embeddings only for missing live paths', async () => {
       mockDb.tableNames.mockResolvedValue(['file_embeddings']);
-      mockTable.query.mockReturnValue({
+      const query = {
+        select: vi.fn().mockReturnThis(),
         where: vi.fn().mockReturnThis(),
         toArray: vi.fn().mockResolvedValue([
           { id: 'keep-file', path: 'src/keep.js', type: 'file', project_path: '/test/project/deep' },
           { id: 'drop-file', path: 'src/drop.js', type: 'file', project_path: '/test/project/deep' },
           { id: 'structure', path: '.', type: 'directory-structure', project_path: '/test/project/deep' },
         ]),
+      };
+      mockTable.query.mockReturnValue({
+        ...query,
       });
       const deleted = await dbManager.pruneProjectFileEmbeddings('/test/project/deep', new Set(['src/keep.js']));
       expect(deleted).toBe(1);
-      expect(mockTable.delete).toHaveBeenCalledWith(expect.stringContaining('drop-file'));
+      expect(query.select).toHaveBeenCalledWith(['id', 'path', 'type']);
+      expect(mockTable.delete).toHaveBeenCalledWith("id IN ('drop-file')");
       expect(mockTable.delete).not.toHaveBeenCalledWith(expect.stringContaining('structure'));
     });
 

--- a/src/embeddings/file-processor.js
+++ b/src/embeddings/file-processor.js
@@ -26,6 +26,7 @@ import { TABLE_NAMES, LANCEDB_DIR_NAME, FASTEMBED_CACHE_DIR_NAME } from './const
 import { createFileProcessingError } from './errors.js';
 
 const FILE_EMBEDDING_BATCH_SIZE = 50;
+const DELETE_BATCH_SIZE = 100;
 const DIRECTORY_STRUCTURE_TYPE = 'directory-structure';
 
 function createShortHash(content) {
@@ -45,6 +46,34 @@ function buildExistingDocumentSignature(chunks) {
     .map((chunk) => `${chunk.id}:${chunk.content_hash}`)
     .sort()
     .join('|');
+}
+
+function buildIdInFilter(ids) {
+  return `id IN (${ids.map((id) => `'${escapeSqlString(id)}'`).join(', ')})`;
+}
+
+async function deleteFileEmbeddingRecords(table, records) {
+  for (let start = 0; start < records.length; start += DELETE_BATCH_SIZE) {
+    const batch = records.slice(start, start + DELETE_BATCH_SIZE);
+
+    try {
+      await table.delete(buildIdInFilter(batch.map((record) => record.id)));
+      batch.forEach((record) => {
+        debug(`Deleted old version: ${record.path} (old hash: ${record.content_hash})`);
+      });
+    }
+    catch {
+      for (const record of batch) {
+        try {
+          await table.delete(`id = '${escapeSqlString(record.id)}'`);
+          debug(`Deleted old version: ${record.path} (old hash: ${record.content_hash})`);
+        }
+        catch (deleteError) {
+          console.warn(chalk.yellow(`Warning: Could not delete old version of ${record.path}: ${deleteError.message}`));
+        }
+      }
+    }
+  }
 }
 
 // ============================================================================
@@ -589,14 +618,8 @@ export class FileProcessor {
         }
       }
 
-      for (const recordToDelete of recordsToDelete.values()) {
-        try {
-          await sharedState.fileTable.delete(`id = '${escapeSqlString(recordToDelete.id)}'`);
-          debug(`Deleted old version: ${recordToDelete.path} (old hash: ${recordToDelete.content_hash})`);
-        }
-        catch (deleteError) {
-          console.warn(chalk.yellow(`Warning: Could not delete old version of ${recordToDelete.path}: ${deleteError.message}`));
-        }
+      if (recordsToDelete.size > 0) {
+        await deleteFileEmbeddingRecords(sharedState.fileTable, Array.from(recordsToDelete.values()));
       }
 
       if (filesToActuallyProcess.length === 0) {

--- a/src/embeddings/file-processor.test.js
+++ b/src/embeddings/file-processor.test.js
@@ -450,7 +450,7 @@ describe('FileProcessor', () => {
           .mockResolvedValue([{ id: 'old-record', path: 'file.js', content_hash: 'different', last_modified: new Date().toISOString() }]),
       });
       const result = await processor.processBatchEmbeddings(['/test/file.js'], { baseDir: '/test' });
-      expect(mockTable.delete).toHaveBeenCalled();
+      expect(mockTable.delete).toHaveBeenCalledWith("id IN ('old-record')");
       expect(result.processed).toBeGreaterThanOrEqual(0);
     });
 


### PR DESCRIPTION
This PR speeds up embedding cleanup paths by batching stale-record deletes and avoiding unnecessary payload reads during project pruning.

- Deletes changed-file stale embedding records with batched id filters.
- Falls back to per-record deletes if a batch delete fails, preserving cleanup behavior on older LanceDB behavior.
- Narrows pruneProjectFileEmbeddings to select only id, path, and type before comparing live paths.
- Batches prune deletes while preserving the directory-structure record guard.
- Adds regression coverage for batched stale-version deletes and the narrowed prune projection.