### PR TITLE
Use async filesystem calls in review hot paths

### DIFF
--- a/src/embeddings/file-processor.js
+++ b/src/embeddings/file-processor.js
@@ -475,7 +475,7 @@ export class FileProcessor {
       const relativePath = path.relative(sharedState.baseDir, absoluteFilePath);
 
       try {
-        const stats = fs.statSync(absoluteFilePath);
+        const stats = await fs.promises.stat(absoluteFilePath);
         const language = detectLanguageFromExtension(path.extname(absoluteFilePath));
 
         if (

--- a/src/embeddings/file-processor.test.js
+++ b/src/embeddings/file-processor.test.js
@@ -8,7 +8,7 @@ vi.mock('node:fs', () => ({
   default: {
     readdirSync: vi.fn(),
     statSync: vi.fn(),
-    promises: { readFile: vi.fn() },
+    promises: { readFile: vi.fn(), stat: vi.fn() },
   },
 }));
 
@@ -61,6 +61,7 @@ vi.mock('../utils/logging.js', () => ({ debug: vi.fn(), verboseLog: vi.fn() }));
 
 const setupFileSystemMocks = (content = 'const x = 1;') => {
   fs.statSync.mockReturnValue({ size: 1000, mtime: new Date(), isFile: () => true });
+  fs.promises.stat.mockResolvedValue({ size: 1000, mtime: new Date(), isFile: () => true });
   fs.promises.readFile.mockResolvedValue(content);
   fs.readdirSync.mockReturnValue([]);
 };
@@ -291,7 +292,7 @@ describe('FileProcessor', () => {
 
     it('should skip files that fail shouldProcessFile check', async () => {
       shouldProcessFile.mockReturnValue(false);
-      fs.statSync.mockReturnValue({ size: 1000, mtime: new Date() });
+      fs.promises.stat.mockResolvedValue({ size: 1000, mtime: new Date() });
       fs.readdirSync.mockReturnValue([]);
       const result = await processor.processBatchEmbeddings(['/test/file.js']);
       expect(result.excluded).toBeGreaterThan(0);
@@ -337,14 +338,14 @@ describe('FileProcessor', () => {
     });
 
     it('should handle file read errors', async () => {
-      fs.statSync.mockReturnValue({ size: 1000, mtime: new Date() });
+      fs.promises.stat.mockResolvedValue({ size: 1000, mtime: new Date() });
       fs.promises.readFile.mockRejectedValue(new Error('Read error'));
       const result = await processor.processBatchEmbeddings(['/test/file.js'], { baseDir: '/test' });
       expect(result.failed).toBeGreaterThanOrEqual(0);
     });
 
     it('should skip large files', async () => {
-      fs.statSync.mockReturnValue({ size: 10 * 1024 * 1024, mtime: new Date() });
+      fs.promises.stat.mockResolvedValue({ size: 10 * 1024 * 1024, mtime: new Date() });
       const result = await processor.processBatchEmbeddings(['/test/large-file.js'], {
         maxFileSizeBytes: 1024 * 1024,
         baseDir: '/test',
@@ -353,9 +354,7 @@ describe('FileProcessor', () => {
     });
 
     it('should handle file stat error', async () => {
-      fs.statSync.mockImplementation(() => {
-        throw new Error('Stat error');
-      });
+      fs.promises.stat.mockRejectedValue(new Error('Stat error'));
       const onProgress = vi.fn();
       const result = await processor.processBatchEmbeddings(['/test/file.js'], { baseDir: '/test', onProgress });
       expect(result.failed).toBe(1);
@@ -518,7 +517,7 @@ describe('FileProcessor', () => {
     });
 
     it('should skip large documentation files', async () => {
-      fs.statSync.mockReturnValue({ size: 6 * 1024 * 1024, mtime: new Date() });
+      fs.promises.stat.mockResolvedValue({ size: 6 * 1024 * 1024, mtime: new Date() });
       fs.promises.readFile.mockResolvedValue('# Large doc');
       expect(await processor.processBatchEmbeddings(['/test/large.md'], { baseDir: '/test' })).toBeDefined();
     });
@@ -620,11 +619,11 @@ describe('FileProcessor', () => {
     });
 
     it('should handle document chunk processing errors', async () => {
-      fs.statSync.mockImplementation((filePath) => {
+      fs.promises.stat.mockImplementation((filePath) => {
         if (filePath.includes('error')) {
-          throw new Error('Stat error');
+          return Promise.reject(new Error('Stat error'));
         }
-        return { size: 1000, mtime: new Date() };
+        return Promise.resolve({ size: 1000, mtime: new Date() });
       });
       fs.promises.readFile.mockResolvedValue('# Title');
       expect(await processor.processBatchEmbeddings(['/test/error.md'], { baseDir: '/test' })).toBeDefined();

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -42,6 +42,20 @@ const embeddingsSystem = getDefaultEmbeddingsSystem();
 // Track if semantic similarity has been initialized
 let semanticSimilarityInitialized = false;
 
+async function fileExists(filePath) {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  }
+  catch {
+    return false;
+  }
+}
+
+async function readTextFile(filePath) {
+  return await fs.promises.readFile(filePath, 'utf8');
+}
+
 /**
  * Initialize semantic similarity for feedback filtering
  * Uses the shared embeddings system from feedback-loader.js
@@ -448,7 +462,7 @@ async function runAnalysis(filePath, options = {}) {
     }
 
     // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    if (!(await fileExists(filePath))) {
       throw new Error(`File not found: ${filePath}`);
     }
 
@@ -458,11 +472,11 @@ async function runAnalysis(filePath, options = {}) {
     if (options.diffOnly && options.diffContent) {
       content = options.diffContent;
       // For PR reviews, always read the full file content for context awareness
-      fullFileContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : null;
+      fullFileContent = await readTextFile(filePath);
       verboseLog(options, chalk.blue(`Analyzing diff only for ${path.basename(filePath)}`));
     }
     else {
-      content = fs.readFileSync(filePath, 'utf8');
+      content = await readTextFile(filePath);
       fullFileContent = content;
       verboseLog(options, chalk.blue(`Analyzing full file ${path.basename(filePath)}`));
     }
@@ -1487,7 +1501,7 @@ async function getPRCommentContext(filePath, options = {}) {
       verboseLog(options, chalk.blue(`🔍 Using pre-computed query embedding for PR comment search`));
       // We still need the file content for the search function, but not for embedding
       try {
-        fileContent = fs.readFileSync(filePath, 'utf8');
+        fileContent = await readTextFile(filePath);
         const maxEmbeddingLength = 8000; // Keep consistent with original truncation
         contentForSearch = fileContent.length > maxEmbeddingLength ? fileContent.substring(0, maxEmbeddingLength) : fileContent;
       }
@@ -1505,7 +1519,7 @@ async function getPRCommentContext(filePath, options = {}) {
     else {
       // Fallback to original behavior if no pre-computed embedding provided
       try {
-        fileContent = fs.readFileSync(filePath, 'utf8');
+        fileContent = await readTextFile(filePath);
       }
       catch (readError) {
         debug(`[getPRCommentContext] Could not read file ${filePath}: ${readError.message}`);

--- a/src/rag-analyzer.test.js
+++ b/src/rag-analyzer.test.js
@@ -41,6 +41,10 @@ vi.mock('node:fs', () => ({
   default: {
     readFileSync: vi.fn(),
     existsSync: vi.fn().mockReturnValue(true),
+    promises: {
+      access: vi.fn().mockResolvedValue(undefined),
+      readFile: vi.fn(),
+    },
   },
 }));
 
@@ -155,6 +159,8 @@ describe('rag-analyzer', () => {
     mockEmbeddingsSystem.updatePRCommentsIndex.mockReset().mockResolvedValue(undefined);
     fs.readFileSync.mockReturnValue('const x = 1;\nconsole.log(x);');
     fs.existsSync.mockReturnValue(true);
+    fs.promises.access.mockReset().mockResolvedValue(undefined);
+    fs.promises.readFile.mockReset().mockResolvedValue('const x = 1;\nconsole.log(x);');
   });
 
   afterEach(() => {
@@ -197,7 +203,7 @@ describe('rag-analyzer', () => {
     });
 
     it('should return error when file does not exist', async () => {
-      fs.existsSync.mockReturnValue(false);
+      fs.promises.access.mockRejectedValue(new Error('ENOENT'));
       const result = await runAnalysis('/test/nonexistent.js');
       expect(result.success).toBe(false);
       expect(result.error).toContain('File not found');
@@ -369,13 +375,13 @@ describe('rag-analyzer', () => {
       ['whitespace only', '   \n\n   '],
       ['normal content', 'const x = 1;\nfunction test() {}'],
     ])('should handle %s', async (_, content) => {
-      fs.readFileSync.mockReturnValue(content);
+      fs.promises.readFile.mockResolvedValue(content);
       const result = await runAnalysis('/test/file.js');
       expect(result).toBeDefined();
     });
 
     it('should handle very long files', async () => {
-      fs.readFileSync.mockReturnValue(createMockLongCode(1000));
+      fs.promises.readFile.mockResolvedValue(createMockLongCode(1000));
       const result = await runAnalysis('/test/long.js');
       expect(result.success).toBe(true);
     });
@@ -954,7 +960,7 @@ describe('rag-analyzer', () => {
 
   describe('gatherUnifiedContextForPR error handling', () => {
     it('should handle file context gathering errors', async () => {
-      fs.readFileSync.mockImplementation((path) => {
+      fs.promises.readFile.mockImplementation((path) => {
         if (path.includes('error-file')) {
           throw new Error('Read error');
         }
@@ -1181,7 +1187,7 @@ describe('rag-analyzer', () => {
           return <div>{data}</div>;
         }
       `;
-      fs.readFileSync.mockReturnValue(richCode);
+      fs.promises.readFile.mockResolvedValue(richCode);
       setupSuccessfulLLMResponse();
       const result = await runAnalysis('/test/Dashboard.jsx');
       expect(result.success).toBe(true);


### PR DESCRIPTION
This PR removes synchronous filesystem calls from the per-file review and embedding candidate hot paths.

- Uses async file existence and read helpers during per-file RAG analysis.
- Reads file content asynchronously while building historical PR comment context.
- Uses fs.promises.stat while preparing embedding candidates.
- Updates affected tests to drive fs.promises mocks instead of sync fs mocks.