### PR TITLE
Right-size holistic PR context

### DIFF
--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -27,6 +27,7 @@ import { isGenericDocument, getGenericDocumentContext } from './utils/document-d
 import { isTestFile, shouldProcessFile } from './utils/file-validation.js';
 import { detectFileType, detectLanguageFromExtension } from './utils/language-detection.js';
 import { debug, verboseLog } from './utils/logging.js';
+import { formatPlannedHolisticFileContext, mergeHolisticFileContextPlans } from './utils/pr-file-context.js';
 import { addLineNumbers } from './utils/string-utils.js';
 
 // Constants for content processing
@@ -1358,23 +1359,24 @@ ${g.content}
 
   // Format PR files with their diffs
   const prFiles = file.prFiles || [];
+  const holisticContextPlans = mergeHolisticFileContextPlans(prFiles, context.options || {});
   const formattedPRFiles = prFiles
     .map((prFile, idx) => {
+      const fileContextPlan = holisticContextPlans[idx];
+      const fileContext = formatPlannedHolisticFileContext(prFile, fileContextPlan, context.options || {});
       return `
 ## FILE ${idx + 1}: ${prFile.path}
 **Language**: ${prFile.language}
 **Type**: ${prFile.isTest ? 'Test' : 'Source'} file
 **Summary**: ${prFile.summary}
+**Context Mode**: ${fileContextPlan.mode === 'full' ? 'Full file content' : 'Focused changed-line context'}
 
 ### Changes (Git Diff):
 \`\`\`diff
 ${prFile.diff}
 \`\`\`
 
-### Full File Content (For Context - line numbers shown for reference):
-\`\`\`${prFile.language}
-${addLineNumbers(prFile.fullContent)}
-\`\`\`
+${fileContext}
 `;
     })
     .join('\n');
@@ -1388,17 +1390,17 @@ ${addLineNumbers(prFile.fullContent)}
 **CRITICAL CONTEXT AWARENESS INSTRUCTIONS:**
 
 For each file in this PR, you have access to:
-1. **FULL FILE CONTENT** - The complete file for understanding context and existing code
+1. **FILE CONTEXT** - Complete file content when it fits the holistic context budget, or focused changed-line windows for very large files/PRs
 2. **GIT DIFF** - Only the changes to review
 
 **Review Rules:**
 - ONLY critique the CHANGED lines shown in each file's diff (lines with + or -)
-- USE the full file content to understand context, dependencies, and existing implementations
+- USE the file context to understand dependencies, nearby behavior, and existing implementations
 - DO NOT suggest adding code that already exists in the unchanged portions of any file
-- DO NOT flag issues about missing code if it exists elsewhere in the full file
-- Before flagging cross-file issues, verify the code doesn't already exist in unchanged portions
-- Do NOT flag functions/variables as missing if they exist elsewhere in the full file
-- The unchanged code is part of each file - always check it before making assumptions`;
+- DO NOT flag issues about missing code when the provided context already shows the code exists
+- Before flagging cross-file issues, verify the code doesn't already exist in the provided context
+- Do NOT flag functions/variables as missing if they exist elsewhere in the provided context
+- The unchanged context is part of each file - always check it before making assumptions`;
 
   let roleDefinition = buildRoleDefinition(baseRole, customDocs, 'pr');
   roleDefinition += '\nAnalyze ALL files together to identify cross-file issues, consistency problems, and overall code quality.';

--- a/src/rag-analyzer.test.js
+++ b/src/rag-analyzer.test.js
@@ -578,6 +578,70 @@ describe('rag-analyzer', () => {
       );
       expect(result.success).toBe(true);
     });
+
+    it('should use focused context for oversized holistic PR files', async () => {
+      const hugeContent = Array.from({ length: 5000 }, (_, index) => `huge line ${index + 1}`).join('\n');
+      llm.sendPromptToClaude.mockResolvedValue(createMockHolisticReviewResponse());
+
+      const result = await runAnalysis(
+        'PR_HOLISTIC_REVIEW',
+        setupHolisticReviewOptions({
+          prFiles: [
+            createMockPRFile({
+              path: 'src/small.js',
+              fullContent: 'const small = true;',
+              diff: '@@ -1,1 +1,1 @@\n-const small = false;\n+const small = true;',
+            }),
+            createMockPRFile({
+              path: 'src/huge.js',
+              fullContent: hugeContent,
+              diff: '@@ -2500,1 +2500,1 @@\n-huge line 2500\n+huge line 2500 changed',
+            }),
+          ],
+          prContext: { totalFiles: 2 },
+          maxTotalFullContentTokens: 1000,
+        })
+      );
+
+      const prompt = llm.sendPromptToClaude.mock.calls.at(-1)[0];
+      expect(result.success).toBe(true);
+      expect(prompt).toContain('**Context Mode**: Full file content');
+      expect(prompt).toContain('**Context Mode**: Focused changed-line context');
+      expect(prompt).toContain('const small = true;');
+      expect(prompt).toContain('Focused File Context');
+      expect(prompt).toContain('2500 | huge line 2500');
+      expect(prompt).not.toContain('5000 | huge line 5000');
+    });
+
+    it('should preserve carried holistic context plans for chunked reviews', async () => {
+      llm.sendPromptToClaude.mockResolvedValue(createMockHolisticReviewResponse());
+
+      await runAnalysis(
+        'PR_HOLISTIC_REVIEW',
+        setupHolisticReviewOptions({
+          prFiles: [
+            createMockPRFile({
+              path: 'src/chunked.js',
+              fullContent: 'const wouldFit = true;',
+              diff: '@@ -1,1 +1,1 @@\n-const wouldFit = false;\n+const wouldFit = true;',
+              holisticContextPlan: {
+                mode: 'focused',
+                reason: 'global budget assigned focused context before chunking',
+                contextTokens: 5,
+                totalTokens: 20,
+                contextLineRadius: 0,
+              },
+            }),
+          ],
+          prContext: { totalFiles: 1 },
+        })
+      );
+
+      const prompt = llm.sendPromptToClaude.mock.calls.at(-1)[0];
+      expect(prompt).toContain('**Context Mode**: Focused changed-line context');
+      expect(prompt).toContain('global budget assigned focused context before chunking');
+      expect(prompt).not.toContain('### Full File Content');
+    });
   });
 
   // ==========================================================================

--- a/src/rag-review.js
+++ b/src/rag-review.js
@@ -14,6 +14,7 @@ import { ensureBranchExists, findParentBranch, getChangedLinesInfo, getFileConte
 import { detectFileType, detectLanguageFromExtension } from './utils/language-detection.js';
 import { verboseLog } from './utils/logging.js';
 import { shouldChunkPR, chunkPRFiles, combineChunkResults } from './utils/pr-chunking.js';
+import { mergeHolisticFileContextPlans } from './utils/pr-file-context.js';
 
 /**
  * Review a single file using RAG approach
@@ -308,8 +309,10 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
     }
 
     // Check if PR should be chunked based on size and complexity (skip if this is already a chunk)
+    let holisticContextPlans = options.holisticContextPlans;
     if (!options.skipChunking) {
       const chunkingDecision = shouldChunkPR(prFiles, options);
+      holisticContextPlans = chunkingDecision.holisticContextPlans;
       verboseLog(verbose, chalk.blue(`PR size assessment: ${chunkingDecision.estimatedTokens} tokens, ${prFiles.length} files`));
       verboseLog(
         verbose && chunkingDecision.shouldChunk,
@@ -319,9 +322,11 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
       // If PR is too large, use chunked processing
       if (chunkingDecision.shouldChunk) {
         verboseLog(options, chalk.blue(`🔄 Using chunked processing for large PR (${chunkingDecision.estimatedTokens} tokens)`));
-        return await reviewLargePRInChunks(prFiles, options);
+        return await reviewLargePRInChunks(prFiles, { ...options, holisticContextPlans });
       }
     }
+
+    holisticContextPlans = mergeHolisticFileContextPlans(prFiles, options, holisticContextPlans);
 
     // Step 2: Gather unified context for the entire PR (for regular-sized PRs)
     verboseLog(verbose, chalk.blue(`Performing unified context retrieval for ${prFiles.length} PR files...`));
@@ -361,7 +366,7 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
     try {
       // Create a comprehensive review context with all files and their diffs
       const comprehensiveContext = {
-        prFiles: prFiles.map((file) => ({
+        prFiles: prFiles.map((file, index) => ({
           path: path.relative(workingDir, file.filePath),
           language: file.language,
           isTest: file.isTest,
@@ -369,6 +374,8 @@ async function reviewPullRequestWithCrossFileContext(filesToReview, options = {}
           summary: file.summary,
           fullContent: file.content, // Add full file content for context
           diff: file.diffContent,
+          diffInfo: file.diffInfo,
+          holisticContextPlan: file.holisticContextPlan || holisticContextPlans[index],
           baseBranch: file.baseBranch,
           targetBranch: file.targetBranch,
         })),
@@ -557,7 +564,7 @@ async function reviewLargePRInChunks(prFiles, options) {
 
   // Step 2: Split PR into manageable chunks
   // Each chunk includes both diff AND full file content, plus ~25k context overhead
-  const chunks = chunkPRFiles(prFiles, 35000); // Conservative limit accounting for context overhead
+  const chunks = chunkPRFiles(prFiles, 35000, options); // Conservative limit accounting for context overhead
   verboseLog(options, chalk.green(`✂️ Split PR into ${chunks.length} chunks`));
 
   chunks.forEach((chunk, i) => {

--- a/src/rag-review.test.js
+++ b/src/rag-review.test.js
@@ -270,7 +270,8 @@ describe('rag-review', () => {
       });
 
       // Setup: shouldChunkPR returns true to trigger chunked processing
-      shouldChunkPR.mockReturnValue({ shouldChunk: true, estimatedTokens: 100000, recommendedChunks: 2 });
+      const holisticContextPlans = [{ mode: 'focused', contextTokens: 10, totalTokens: 20 }];
+      shouldChunkPR.mockReturnValue({ shouldChunk: true, estimatedTokens: 100000, recommendedChunks: 2, holisticContextPlans });
 
       // Setup chunks that will be processed
       chunkPRFiles.mockReturnValue([
@@ -298,7 +299,7 @@ describe('rag-review', () => {
 
       // Verify chunking flow was triggered
       expect(shouldChunkPR).toHaveBeenCalled();
-      expect(chunkPRFiles).toHaveBeenCalled();
+      expect(chunkPRFiles).toHaveBeenCalledWith(expect.any(Array), 35000, expect.objectContaining({ holisticContextPlans }));
       expect(combineChunkResults).toHaveBeenCalled();
       expect(result.success).toBe(true);
     });

--- a/src/utils/diff-lines.js
+++ b/src/utils/diff-lines.js
@@ -1,0 +1,60 @@
+/**
+ * Parse git unified diff hunks into new-file line metadata.
+ *
+ * @param {string} diffContent - Git diff text.
+ * @param {object} options - Parser options.
+ * @param {boolean} [options.includeRemovalAnchors=false] - Include deletion anchors in changedLineNumbers.
+ * @param {boolean} [options.includeHunkStartFallback=false] - Use hunk starts when a hunk has no added/deleted anchors.
+ * @returns {{addedLines: Array<{lineNumber: number, content: string}>, removedLines: Array<{content: string}>, contextLines: Array<{lineNumber: number, content: string}>, changedLineNumbers: number[]}}
+ */
+export function parseDiffLineInfo(diffContent = '', options = {}) {
+  const addedLines = [];
+  const removedLines = [];
+  const contextLines = [];
+  const changedLineNumbers = [];
+  const hunkStartLines = [];
+  const lines = diffContent.split('\n');
+  let currentNewLine = null;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      currentNewLine = null;
+      continue;
+    }
+
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      currentNewLine = Number.parseInt(hunkMatch[1], 10);
+      hunkStartLines.push(Math.max(1, currentNewLine));
+      continue;
+    }
+
+    if (currentNewLine === null) {
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      const lineNumber = Math.max(1, currentNewLine);
+      addedLines.push({ lineNumber, content: line.slice(1) });
+      changedLineNumbers.push(lineNumber);
+      currentNewLine++;
+    }
+    else if (line.startsWith('-')) {
+      removedLines.push({ content: line.slice(1) });
+      if (options.includeRemovalAnchors) {
+        changedLineNumbers.push(Math.max(1, currentNewLine));
+      }
+    }
+    else if (line.startsWith(' ')) {
+      contextLines.push({ lineNumber: currentNewLine, content: line.slice(1) });
+      currentNewLine++;
+    }
+  }
+
+  return {
+    addedLines,
+    removedLines,
+    contextLines,
+    changedLineNumbers: changedLineNumbers.length > 0 || !options.includeHunkStartFallback ? changedLineNumbers : hunkStartLines,
+  };
+}

--- a/src/utils/diff-lines.test.js
+++ b/src/utils/diff-lines.test.js
@@ -1,0 +1,36 @@
+import { parseDiffLineInfo } from './diff-lines.js';
+
+describe('parseDiffLineInfo', () => {
+  it('does not count file headers as changes in multi-file diffs', () => {
+    const diff = [
+      'diff --git a/f1.js b/f1.js',
+      '--- a/f1.js',
+      '+++ b/f1.js',
+      '@@ -1,1 +1,1 @@',
+      '-old1',
+      '+new1',
+      'diff --git a/f2.js b/f2.js',
+      '--- a/f2.js',
+      '+++ b/f2.js',
+      '@@ -3,1 +3,1 @@',
+      '-old2',
+      '+new2',
+    ].join('\n');
+
+    const result = parseDiffLineInfo(diff, { includeRemovalAnchors: true });
+
+    expect(result.addedLines).toEqual([
+      { lineNumber: 1, content: 'new1' },
+      { lineNumber: 3, content: 'new2' },
+    ]);
+    expect(result.removedLines).toEqual([{ content: 'old1' }, { content: 'old2' }]);
+    expect(result.changedLineNumbers).toEqual([1, 1, 3, 3]);
+  });
+
+  it('still treats code lines starting with ++ as additions inside hunks', () => {
+    const result = parseDiffLineInfo('@@ -10,0 +10,1 @@\n+++counter;', { includeRemovalAnchors: true });
+
+    expect(result.addedLines).toEqual([{ lineNumber: 10, content: '++counter;' }]);
+    expect(result.changedLineNumbers).toEqual([10]);
+  });
+});

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -9,6 +9,7 @@ import { execSync } from 'child_process';
 import path from 'path';
 import chalk from 'chalk';
 import { execGitSafe } from './command.js';
+import { parseDiffLineInfo } from './diff-lines.js';
 import { verboseLog } from './logging.js';
 
 /**
@@ -317,33 +318,7 @@ export function getChangedLinesInfo(filePath, baseBranch, targetBranch, workingD
       return { hasChanges: false, addedLines: [], removedLines: [], contextLines: [] };
     }
 
-    const lines = diffOutput.split('\n');
-    const addedLines = [];
-    const removedLines = [];
-    const contextLines = [];
-
-    let currentLineNumber = 0;
-
-    for (const line of lines) {
-      if (line.startsWith('@@')) {
-        // Parse line numbers from diff header like "@@ -10,7 +10,8 @@"
-        const match = line.match(/@@ -(\d+),?\d* \+(\d+),?\d* @@/);
-        if (match) {
-          currentLineNumber = parseInt(match[2]);
-        }
-      }
-      else if (line.startsWith('+') && !line.startsWith('+++')) {
-        addedLines.push({ lineNumber: currentLineNumber, content: line.substring(1) });
-        currentLineNumber++;
-      }
-      else if (line.startsWith('-') && !line.startsWith('---')) {
-        removedLines.push({ content: line.substring(1) });
-      }
-      else if (line.startsWith(' ')) {
-        contextLines.push({ lineNumber: currentLineNumber, content: line.substring(1) });
-        currentLineNumber++;
-      }
-    }
+    const { addedLines, removedLines, contextLines } = parseDiffLineInfo(diffOutput);
 
     return {
       hasChanges: addedLines.length > 0 || removedLines.length > 0,

--- a/src/utils/pr-chunking.js
+++ b/src/utils/pr-chunking.js
@@ -1,12 +1,17 @@
 import chalk from 'chalk';
 import { verboseLog } from './logging.js';
+import {
+  CHARS_PER_ESTIMATED_TOKEN,
+  diffCost,
+  fileCost,
+  fitHolisticPlanToChunk,
+  mergeHolisticFileContextPlans,
+  planContextCost,
+  rawFullContentCost,
+  estimatePrContextTokens,
+} from './pr-file-context.js';
 
-const CHARS_PER_ESTIMATED_TOKEN = 3;
 const FULL_CONTENT_CONTEXT_TOKEN_RATIO = 0.25;
-
-function estimateTokens(text) {
-  return Math.ceil((text?.length || 0) / CHARS_PER_ESTIMATED_TOKEN);
-}
 
 /**
  * Determines if a PR should be chunked based on estimated token usage
@@ -16,21 +21,26 @@ function estimateTokens(text) {
  * @returns {Object} Decision object with shouldChunk flag and estimates
  */
 export function shouldChunkPR(prFiles, options = {}) {
-  // IMPORTANT: The holistic PR prompt includes BOTH full file content AND diff content
-  // for each file, plus context (code examples, guidelines, PR comments, custom docs)
+  // IMPORTANT: The holistic PR prompt includes diff content plus adaptive file context:
+  // full content while it fits the budget, focused changed-line windows for very large files/PRs.
+  const holisticContextPlans = mergeHolisticFileContextPlans(prFiles, options, options.holisticContextPlans);
 
   // Calculate tokens for diff content
   const diffTokens = prFiles.reduce((sum, file) => {
-    return sum + estimateTokens(file.diffContent);
+    return sum + diffCost(file);
   }, 0);
 
-  // Calculate tokens for full file content (included in prompt for context awareness)
+  // Calculate raw full file tokens for observability
   const fullContentTokens = prFiles.reduce((sum, file) => {
-    return sum + estimateTokens(file.content);
+    return sum + rawFullContentCost(file);
   }, 0);
 
-  // Total file-related tokens (both diff AND full content are sent)
-  const fileTokens = diffTokens + fullContentTokens;
+  const plannedFileContextTokens = holisticContextPlans.reduce((sum, plan) => {
+    return sum + planContextCost(plan);
+  }, 0);
+
+  // Total file-related tokens (diff plus planned full/focused context)
+  const fileTokens = diffTokens + plannedFileContextTokens;
 
   // Estimate context overhead (code examples, guidelines, PR comments, custom docs, project summary)
   // This is typically 10-30k tokens depending on project size
@@ -48,7 +58,7 @@ export function shouldChunkPR(prFiles, options = {}) {
   verboseLog(
     options,
     chalk.gray(
-      `  Token breakdown: ${diffTokens} diff + ${fullContentTokens} full content + ${CONTEXT_OVERHEAD_TOKENS} context overhead = ${totalEstimatedTokens} total`
+      `  Token breakdown: ${diffTokens} diff + ${plannedFileContextTokens} planned file context (${fullContentTokens} raw full content) + ${CONTEXT_OVERHEAD_TOKENS} context overhead = ${totalEstimatedTokens} total`
     )
   );
 
@@ -57,6 +67,8 @@ export function shouldChunkPR(prFiles, options = {}) {
     estimatedTokens: totalEstimatedTokens,
     diffTokens,
     fullContentTokens,
+    plannedFileContextTokens,
+    holisticContextPlans,
     contextOverhead: CONTEXT_OVERHEAD_TOKENS,
     recommendedChunks: Math.ceil(totalEstimatedTokens / 35000), // More aggressive chunking
   };
@@ -66,18 +78,22 @@ export function shouldChunkPR(prFiles, options = {}) {
  * Chunks PR files into manageable groups based on token limits and logical grouping
  * @param {Array} prFiles - Array of PR files with diffContent and content
  * @param {number} maxTokensPerChunk - Maximum tokens per chunk
+ * @param {Object} options - Chunking options
  * @returns {Array} Array of chunks with files and metadata
  */
-export function chunkPRFiles(prFiles, maxTokensPerChunk = 35000) {
+export function chunkPRFiles(prFiles, maxTokensPerChunk = 35000, options = {}) {
+  const holisticContextPlans = mergeHolisticFileContextPlans(prFiles, options, options.holisticContextPlans);
+
   // Calculate change complexity for each file (works for any language)
-  // IMPORTANT: Token estimate must include BOTH diff AND full content since both are sent
-  const filesWithMetrics = prFiles.flatMap((file) => {
+  // IMPORTANT: Token estimate must match the adaptive holistic prompt context plan.
+  const filesWithMetrics = prFiles.flatMap((file, index) => {
+    const fileContextPlan = holisticContextPlans[index];
     const fileWithMetrics = {
       ...file,
+      holisticContextPlan: fileContextPlan,
       changeSize: calculateChangeSize(file.diffContent),
       fileComplexity: calculateFileComplexity(file),
-      // Estimate tokens for BOTH diff content AND full file content (both are included in prompt)
-      estimatedTokens: estimateTokens(file.diffContent) + estimateTokens(file.content),
+      estimatedTokens: fileCost(fileContextPlan),
     };
 
     return splitOversizedFileForChunk(fileWithMetrics, maxTokensPerChunk);
@@ -135,7 +151,11 @@ function splitOversizedFileForChunk(file, maxTokensPerChunk) {
     return [file];
   }
 
-  const diffTokens = estimateTokens(file.diffContent);
+  const diffTokens = diffCost(file);
+  if (file.holisticContextPlan?.mode === 'focused' && diffTokens <= maxTokensPerChunk) {
+    return [capFocusedContextForChunk(file, maxTokensPerChunk)];
+  }
+
   if (diffTokens <= maxTokensPerChunk) {
     return [capFileContentForChunk(file, maxTokensPerChunk, diffTokens)];
   }
@@ -145,19 +165,42 @@ function splitOversizedFileForChunk(file, maxTokensPerChunk) {
   const diffParts = splitDiffToTokenBudget(file.diffContent, diffBudget);
   const cappedContent = truncateToTokenBudget(file.content, contentBudget, 'file content');
 
-  return diffParts.map((diffPart, index) => ({
+  return diffParts.map((diffPart, index) => {
+    const splitFile = {
+      ...file,
+      diffContent: diffPart,
+      diffInfo: undefined,
+      diffSplitForChunk: true,
+      chunkPart: index + 1,
+      chunkParts: diffParts.length,
+      originalEstimatedTokens: file.estimatedTokens,
+      originalDiffEstimatedTokens: diffTokens,
+      summary: `${file.summary || pathBasename(file.filePath)} (diff part ${index + 1}/${diffParts.length})`,
+    };
+
+    if (file.holisticContextPlan?.mode === 'focused') {
+      return capFocusedContextForChunk(splitFile, maxTokensPerChunk);
+    }
+
+    return {
+      ...splitFile,
+      content: cappedContent,
+      estimatedTokens: estimatePrContextTokens(diffPart) + estimatePrContextTokens(cappedContent),
+      truncatedForChunk: cappedContent !== file.content,
+    };
+  });
+}
+
+function capFocusedContextForChunk(file, maxTokensPerChunk) {
+  const adjustedPlan = fitHolisticPlanToChunk(file, file.holisticContextPlan, maxTokensPerChunk);
+
+  return {
     ...file,
-    diffContent: diffPart,
-    content: cappedContent,
-    estimatedTokens: estimateTokens(diffPart) + estimateTokens(cappedContent),
-    truncatedForChunk: cappedContent !== file.content,
-    diffSplitForChunk: true,
-    chunkPart: index + 1,
-    chunkParts: diffParts.length,
-    originalEstimatedTokens: file.estimatedTokens,
-    originalDiffEstimatedTokens: diffTokens,
-    summary: `${file.summary || pathBasename(file.filePath)} (diff part ${index + 1}/${diffParts.length})`,
-  }));
+    holisticContextPlan: adjustedPlan,
+    estimatedTokens: fileCost(adjustedPlan),
+    focusedContextReducedForChunk: adjustedPlan.contextTokens < (file.holisticContextPlan?.contextTokens || Number.POSITIVE_INFINITY),
+    originalEstimatedTokens: file.originalEstimatedTokens ?? file.estimatedTokens,
+  };
 }
 
 function capFileContentForChunk(file, maxTokensPerChunk, diffTokens) {
@@ -167,14 +210,14 @@ function capFileContentForChunk(file, maxTokensPerChunk, diffTokens) {
   return {
     ...file,
     content: cappedContent,
-    estimatedTokens: diffTokens + estimateTokens(cappedContent),
+    estimatedTokens: diffTokens + estimatePrContextTokens(cappedContent),
     truncatedForChunk: cappedContent !== file.content,
     originalEstimatedTokens: file.estimatedTokens,
   };
 }
 
 function splitDiffToTokenBudget(diffContent, tokenBudget) {
-  if (!diffContent || estimateTokens(diffContent) <= tokenBudget) {
+  if (!diffContent || estimatePrContextTokens(diffContent) <= tokenBudget) {
     return [diffContent || ''];
   }
 
@@ -241,9 +284,12 @@ function splitDiffIntoUnits(lines) {
 
 function splitLargeDiffUnit(headerText, unit, maxChars, hasPreviousPart) {
   const parts = [];
+  const hunkHeader = unit.split('\n').find((line) => line.startsWith('@@'));
 
   for (let offset = 0; offset < unit.length; ) {
-    const prefix = buildBoundedDiffPrefix(headerText, hasPreviousPart || parts.length > 0, maxChars);
+    const isContinuation = hasPreviousPart || parts.length > 0;
+    const continuationHunkHeader = offset > 0 ? adjustHunkHeaderNewStart(hunkHeader, estimateNewLineAtOffset(unit, offset)) : '';
+    const prefix = buildBoundedDiffPrefix(headerText, isContinuation, maxChars, continuationHunkHeader);
     const sliceChars = Math.max(maxChars - prefix.length, 1);
     const slice = unit.slice(offset, offset + sliceChars);
     parts.push(`${prefix}${slice}`);
@@ -253,14 +299,61 @@ function splitLargeDiffUnit(headerText, unit, maxChars, hasPreviousPart) {
   return parts;
 }
 
-function buildBoundedDiffPrefix(headerText, isContinuation, maxChars) {
-  const prefixText = [headerText, isContinuation ? splitMarker() : ''].filter(Boolean).join('\n');
-  if (!prefixText || maxChars <= 1) {
+function estimateNewLineAtOffset(unit, offset) {
+  let currentNewLine = null;
+  let currentOffset = 0;
+
+  for (const line of unit.split('\n')) {
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    const lineEndOffset = currentOffset + line.length + 1;
+
+    if (hunkMatch) {
+      currentNewLine = Number.parseInt(hunkMatch[1], 10);
+      if (offset < lineEndOffset) {
+        return Math.max(1, currentNewLine);
+      }
+      currentOffset = lineEndOffset;
+      continue;
+    }
+
+    if (currentNewLine !== null) {
+      if (offset < lineEndOffset) {
+        return Math.max(1, currentNewLine);
+      }
+
+      if (line.startsWith('+') || line.startsWith(' ')) {
+        currentNewLine++;
+      }
+    }
+
+    currentOffset = lineEndOffset;
+  }
+
+  return Math.max(1, currentNewLine || 1);
+}
+
+function adjustHunkHeaderNewStart(hunkHeader, newStartLine) {
+  if (!hunkHeader) {
     return '';
   }
 
-  const maxPrefixChars = Math.max(maxChars - 2, 0);
-  const boundedPrefix = prefixText.length > maxPrefixChars ? prefixText.slice(0, maxPrefixChars) : prefixText;
+  return hunkHeader.replace(/^(@@ -\d+(?:,\d+)? )\+\d+((?:,\d+)? @@.*)$/, `$1+${newStartLine}$2`);
+}
+
+function buildBoundedDiffPrefix(headerText, isContinuation, maxChars, hunkHeader = '') {
+  let requiredTail = [isContinuation ? splitMarker() : '', hunkHeader].filter(Boolean).join('\n');
+  if (requiredTail.length + 1 >= maxChars) {
+    requiredTail = hunkHeader && hunkHeader.length + 1 < maxChars ? hunkHeader : '';
+  }
+
+  if ((!headerText && !requiredTail) || maxChars <= 1) {
+    return '';
+  }
+
+  const requiredTailWithNewline = requiredTail ? `${requiredTail}\n` : '';
+  const maxHeaderChars = Math.max(maxChars - requiredTailWithNewline.length - 2, 0);
+  const boundedHeader = headerText.length > maxHeaderChars ? headerText.slice(0, maxHeaderChars) : headerText;
+  const boundedPrefix = [boundedHeader, requiredTail].filter(Boolean).join('\n');
   return boundedPrefix ? `${boundedPrefix}\n` : '';
 }
 

--- a/src/utils/pr-chunking.test.js
+++ b/src/utils/pr-chunking.test.js
@@ -59,6 +59,21 @@ describe('shouldChunkPR', () => {
       const result = shouldChunkPR(prFiles);
       expect(result.recommendedChunks).toBeGreaterThan(1);
     });
+
+    it('should not chunk only because a huge file has a tiny diff', () => {
+      const prFiles = [
+        {
+          filePath: 'src/huge.js',
+          diffContent: '@@ -10,1 +10,1 @@\n-old value\n+new value',
+          content: Array.from({ length: 10000 }, (_, index) => `line ${index + 1}`).join('\n'),
+        },
+      ];
+
+      const result = shouldChunkPR(prFiles, { maxTotalFullContentTokens: 1000 });
+
+      expect(result.fullContentTokens).toBeGreaterThan(result.plannedFileContextTokens);
+      expect(result.shouldChunk).toBe(false);
+    });
   });
 
   describe('edge cases', () => {
@@ -118,6 +133,44 @@ describe('chunkPRFiles', () => {
       const prFiles = [{ filePath: 'src/file.js', diffContent: 'abc', content: 'def' }];
       const chunks = chunkPRFiles(prFiles);
       expect(chunks[0].totalTokens).toBeGreaterThan(0);
+    });
+
+    it('should attach holistic context plans to chunked files', () => {
+      const prFiles = [
+        {
+          filePath: 'src/huge.js',
+          diffContent: '@@ -10,1 +10,1 @@\n-old value\n+new value',
+          content: Array.from({ length: 10000 }, (_, index) => `line ${index + 1}`).join('\n'),
+        },
+      ];
+
+      const chunks = chunkPRFiles(prFiles, 35000, { maxTotalFullContentTokens: 1000 });
+
+      expect(chunks[0].files[0].holisticContextPlan.mode).toBe('focused');
+      expect(chunks[0].files[0].estimatedTokens).toBe(chunks[0].totalTokens);
+    });
+
+    it('should shrink focused context plans instead of truncating content when chunking focused files', () => {
+      const content = Array.from({ length: 2000 }, (_, index) => `line ${index + 1}`).join('\n');
+      const scatteredDiff = [
+        'diff --git a/src/huge.js b/src/huge.js',
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        ...Array.from({ length: 60 }, (_, index) => {
+          const line = index * 30 + 10;
+          return `@@ -${line},1 +${line},1 @@\n-line ${line}\n+line ${line} changed`;
+        }),
+      ].join('\n');
+
+      const chunks = chunkPRFiles([{ filePath: 'src/huge.js', diffContent: scatteredDiff, content }], 1500, {
+        maxTotalFullContentTokens: 1,
+      });
+      const chunkedFile = chunks[0].files[0];
+
+      expect(chunkedFile.holisticContextPlan.mode).toBe('focused');
+      expect(chunkedFile.holisticContextPlan.maxFocusedContextTokens).toBeLessThan(1500);
+      expect(chunkedFile.truncatedForChunk).toBeUndefined();
+      expect(chunks.every((chunk) => chunk.totalTokens <= 1500)).toBe(true);
     });
   });
 
@@ -182,6 +235,79 @@ describe('chunkPRFiles', () => {
       expect(combinedDiff).toContain('changed sentinel-0');
       expect(combinedDiff).toContain('changed sentinel-45');
       expect(combinedDiff).toContain('changed sentinel-89');
+    });
+
+    it('should clear whole-file diffInfo on focused split parts so each part anchors its own diff slice', () => {
+      const hugeDiff = [
+        'diff --git a/src/huge.js b/src/huge.js',
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        ...Array.from({ length: 90 }, (_, i) => `@@ -${i + 1},1 +${i + 1},1 @@\n-context ${i}\n+changed sentinel-${i} ${'x'.repeat(5000)}`),
+      ].join('\n');
+      const prFiles = [
+        {
+          filePath: 'src/huge.js',
+          diffContent: hugeDiff,
+          content: Array.from({ length: 200 }, (_, index) => `line ${index + 1}`).join('\n'),
+          diffInfo: {
+            addedLines: Array.from({ length: 90 }, (_, index) => ({ lineNumber: index + 1, content: `changed ${index}` })),
+          },
+        },
+      ];
+
+      const chunks = chunkPRFiles(prFiles, 35000, { maxTotalFullContentTokens: 1 });
+      const splitFiles = chunks.flatMap((chunk) => chunk.files);
+
+      expect(splitFiles.length).toBeGreaterThan(1);
+      expect(splitFiles.every((file) => file.diffSplitForChunk)).toBe(true);
+      expect(splitFiles.every((file) => file.diffInfo === undefined)).toBe(true);
+    });
+
+    it('should preserve hunk headers on char-split diff continuations for focused context anchoring', () => {
+      const hugeDiff = [
+        'diff --git a/src/huge.js b/src/huge.js',
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        `@@ -150,1 +150,1 @@\n-old\n+${'x'.repeat(120000)}`,
+      ].join('\n');
+
+      const chunks = chunkPRFiles([{ filePath: 'src/huge.js', diffContent: hugeDiff, content: 'y'.repeat(1200) }], 35000, {
+        maxTotalFullContentTokens: 1,
+      });
+      const splitFiles = chunks.flatMap((chunk) => chunk.files);
+
+      expect(splitFiles.length).toBeGreaterThan(1);
+      expect(splitFiles.slice(1).every((file) => file.diffContent.includes('@@ -150,1 +150,1 @@'))).toBe(true);
+    });
+
+    it('should adjust char-split continuation hunk headers toward the slice line range', () => {
+      const hugeDiff = [
+        'diff --git a/src/huge.js b/src/huge.js',
+        '--- a/src/huge.js',
+        '+++ b/src/huge.js',
+        '@@ -150,0 +150,2000 @@',
+        ...Array.from({ length: 2000 }, (_, index) => `+changed ${index} ${'x'.repeat(90)}`),
+      ].join('\n');
+
+      const chunks = chunkPRFiles(
+        [
+          {
+            filePath: 'src/huge.js',
+            diffContent: hugeDiff,
+            content: Array.from({ length: 2500 }, (_, index) => `line ${index + 1}`).join('\n'),
+          },
+        ],
+        35000,
+        { maxTotalFullContentTokens: 1 }
+      );
+      const splitFiles = chunks.flatMap((chunk) => chunk.files);
+      const continuationStart = splitFiles
+        .slice(1)
+        .map((file) => file.diffContent.match(/@@ -150,0 \+(\d+),2000 @@/)?.[1])
+        .find(Boolean);
+
+      expect(splitFiles.length).toBeGreaterThan(1);
+      expect(Number(continuationStart)).toBeGreaterThan(150);
     });
 
     it('should keep split diff parts within budget for tiny budgets with large headers', () => {

--- a/src/utils/pr-file-context.js
+++ b/src/utils/pr-file-context.js
@@ -1,0 +1,438 @@
+import { parseDiffLineInfo } from './diff-lines.js';
+import { addLineNumbers } from './string-utils.js';
+
+export const CHARS_PER_ESTIMATED_TOKEN = 3;
+const DEFAULT_CONTEXT_LINE_RADIUS = 40;
+const DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE = 12000;
+export const DEFAULT_MAX_TOTAL_FULL_CONTENT_TOKENS = 60000;
+const DEFAULT_MAX_SINGLE_FILE_BUDGET_SHARE = 0.5;
+
+/**
+ * @typedef {object} HolisticFileContextPlan
+ * @property {number} index - Original PR file index.
+ * @property {string} path - Display path for observability.
+ * @property {'full' | 'focused'} mode - Context rendering mode.
+ * @property {string} reason - Human-readable rendering reason for the prompt.
+ * @property {number} fullContentTokens - Estimated token cost of complete file content.
+ * @property {number} diffTokens - Estimated token cost of the diff paired with this plan.
+ * @property {number} contextTokens - Estimated token cost of rendered file context only.
+ * @property {number} totalTokens - Estimated token cost of diff plus rendered file context.
+ * @property {number} contextLineRadius - Focused-context line radius selected by planning.
+ * @property {number | undefined} maxFocusedContextTokens - Focused-context token ceiling selected by chunking.
+ */
+
+export function estimatePrContextTokens(text) {
+  return Math.ceil((text?.length || 0) / CHARS_PER_ESTIMATED_TOKEN);
+}
+
+function getFilePath(file, index) {
+  return file.filePath || file.path || `file-${index + 1}`;
+}
+
+function getFileContent(file) {
+  return file.fullContent ?? file.content ?? '';
+}
+
+function getChangedLineAnchors(file) {
+  const diffInfoLineNumbers = (file.diffInfo?.addedLines || [])
+    .map((line) => line?.lineNumber)
+    .filter((lineNumber) => Number.isInteger(lineNumber) && lineNumber > 0);
+  const parsedLineNumbers = parseDiffLineInfo(file.diff || file.diffContent, {
+    includeRemovalAnchors: true,
+    includeHunkStartFallback: true,
+  }).changedLineNumbers;
+
+  return [...diffInfoLineNumbers, ...parsedLineNumbers];
+}
+
+function normalizeLineNumbers(lineNumbers, totalLines) {
+  if (totalLines <= 0) {
+    return [];
+  }
+
+  return [...new Set(lineNumbers.map((lineNumber) => Math.min(Math.max(lineNumber, 1), totalLines)))].sort((a, b) => a - b);
+}
+
+function mergeLineWindows(normalizedLines, totalLines, radius) {
+  const windows = [];
+
+  for (const lineNumber of normalizedLines) {
+    const nextWindow = {
+      start: Math.max(1, lineNumber - radius),
+      end: Math.min(totalLines, lineNumber + radius),
+    };
+
+    if (nextWindow.start > nextWindow.end) {
+      continue;
+    }
+
+    const previousWindow = windows.at(-1);
+
+    if (previousWindow && nextWindow.start <= previousWindow.end + 1) {
+      previousWindow.end = Math.max(previousWindow.end, nextWindow.end);
+    }
+    else {
+      windows.push(nextWindow);
+    }
+  }
+
+  return windows;
+}
+
+function addLineNumbersForRange(lines, startLine) {
+  const width = String(startLine + lines.length - 1).length;
+  return lines.map((line, index) => `${String(startLine + index).padStart(width)} | ${line}`).join('\n');
+}
+
+function renderFocusedContext(file, plan, lines, windows) {
+  const renderedWindows = windows
+    .map((window, index) => {
+      const windowLines = lines.slice(window.start - 1, window.end);
+      return `#### Context Window ${index + 1}: lines ${window.start}-${window.end}
+\`\`\`${file.language || ''}
+${addLineNumbersForRange(windowLines, window.start)}
+\`\`\``;
+    })
+    .join('\n\n');
+
+  const includedLineCount = windows.reduce((sum, window) => sum + (window.end - window.start + 1), 0);
+  const omittedLineCount = Math.max(0, lines.length - includedLineCount);
+  const windowSection =
+    renderedWindows || '_No focused file context windows fit within the chunk token budget; use the diff above for the exact change._';
+
+  return `### Focused File Context
+Full file content omitted to control prompt size. Included ${includedLineCount} of ${lines.length} lines around changed hunks; omitted ${omittedLineCount} unchanged lines.
+Reason: ${plan.reason}.
+
+${windowSection}`;
+}
+
+function estimateLineRangeTokens(lines, startLine, endLine) {
+  return estimatePrContextTokens(addLineNumbersForRange(lines.slice(startLine - 1, endLine), startLine));
+}
+
+function estimateFocusedWindowTokens(file, lines, window) {
+  const windowShell = `#### Context Window 1: lines ${window.start}-${window.end}
+\`\`\`${file.language || ''}
+
+\`\`\``;
+  return estimatePrContextTokens(windowShell) + estimateLineRangeTokens(lines, window.start, window.end);
+}
+
+function estimateFocusedContextTokens(file, plan, lines, windows) {
+  const includedLineCount = windows.reduce((sum, window) => sum + (window.end - window.start + 1), 0);
+  const omittedLineCount = Math.max(0, lines.length - includedLineCount);
+  const preambleTokens = estimatePrContextTokens(`### Focused File Context
+Full file content omitted to control prompt size. Included ${includedLineCount} of ${lines.length} lines around changed hunks; omitted ${omittedLineCount} unchanged lines.
+Reason: ${plan.reason}.
+
+`);
+
+  if (windows.length === 0) {
+    return (
+      preambleTokens +
+      estimatePrContextTokens(
+        '_No focused file context windows fit within the chunk token budget; use the diff above for the exact change._'
+      )
+    );
+  }
+
+  return windows.reduce((sum, window) => sum + estimateFocusedWindowTokens(file, lines, window), preambleTokens);
+}
+
+function selectMinimalWindowsUntilBudget(file, plan, lines, lineNumbers, maxContextTokens) {
+  const windows = [];
+  let estimatedTokens = estimateFocusedContextTokens(file, plan, lines, []);
+
+  for (const lineNumber of lineNumbers) {
+    const candidateWindow = { start: lineNumber, end: lineNumber };
+    const candidateTokens = estimatedTokens + estimateFocusedWindowTokens(file, lines, candidateWindow);
+    if (candidateTokens > maxContextTokens) {
+      break;
+    }
+
+    windows.push(candidateWindow);
+    estimatedTokens = candidateTokens;
+  }
+
+  return windows;
+}
+
+function enforceRenderedContextBudget(file, plan, lines, windows, maxContextTokens) {
+  if (!Number.isFinite(maxContextTokens)) {
+    return windows;
+  }
+
+  let fittedWindows = [...windows];
+  while (fittedWindows.length > 0 && estimatePrContextTokens(renderFocusedContext(file, plan, lines, fittedWindows)) > maxContextTokens) {
+    fittedWindows = fittedWindows.slice(0, -1);
+  }
+
+  return fittedWindows;
+}
+
+/**
+ * Fit focused context windows within a token budget, shrinking radius before dropping anchors.
+ *
+ * @param {object} file - PR file metadata.
+ * @param {object} plan - Focused-context plan.
+ * @param {string[]} lines - Current file content split by line.
+ * @param {number[]} lineNumbers - Candidate changed-line anchors.
+ * @param {number} radius - Preferred context radius.
+ * @param {number | undefined} maxContextTokens - Optional token ceiling for focused context.
+ * @returns {Array<{start: number, end: number}>} Windows to render.
+ */
+function fitWindowsToTokenBudget(file, plan, lines, lineNumbers, radius, maxContextTokens) {
+  const normalizedLines = normalizeLineNumbers(lineNumbers, lines.length);
+
+  if (!Number.isFinite(maxContextTokens)) {
+    return mergeLineWindows(normalizedLines, lines.length, radius);
+  }
+
+  if (maxContextTokens <= 0 || normalizedLines.length === 0) {
+    return [];
+  }
+
+  const fullRadiusWindows = mergeLineWindows(normalizedLines, lines.length, radius);
+  if (estimateFocusedContextTokens(file, plan, lines, fullRadiusWindows) <= maxContextTokens) {
+    return enforceRenderedContextBudget(file, plan, lines, fullRadiusWindows, maxContextTokens);
+  }
+
+  const minimalWindows = mergeLineWindows(normalizedLines, lines.length, 0);
+  if (estimateFocusedContextTokens(file, plan, lines, minimalWindows) > maxContextTokens) {
+    return enforceRenderedContextBudget(
+      file,
+      plan,
+      lines,
+      selectMinimalWindowsUntilBudget(file, plan, lines, normalizedLines, maxContextTokens),
+      maxContextTokens
+    );
+  }
+
+  let bestWindows = minimalWindows;
+  let low = 0;
+  let high = radius;
+
+  while (low <= high) {
+    const candidateRadius = Math.floor((low + high) / 2);
+    const candidateWindows = mergeLineWindows(normalizedLines, lines.length, candidateRadius);
+    const candidateTokens = estimateFocusedContextTokens(file, plan, lines, candidateWindows);
+
+    if (candidateTokens <= maxContextTokens) {
+      bestWindows = candidateWindows;
+      low = candidateRadius + 1;
+    }
+    else {
+      high = candidateRadius - 1;
+    }
+  }
+
+  return enforceRenderedContextBudget(file, plan, lines, bestWindows, maxContextTokens);
+}
+
+export function buildFocusedFileContext(file, plan, options = {}) {
+  const radius = options.contextLineRadius ?? plan.contextLineRadius ?? DEFAULT_CONTEXT_LINE_RADIUS;
+  const maxContextTokens = options.maxFocusedContextTokens ?? plan.maxFocusedContextTokens;
+  const content = getFileContent(file);
+  const lines = content.split('\n');
+  let changedLines = getChangedLineAnchors(file);
+
+  if (changedLines.length === 0) {
+    changedLines = [1];
+  }
+
+  const windows = fitWindowsToTokenBudget(file, plan, lines, changedLines, radius, maxContextTokens);
+
+  return renderFocusedContext(file, plan, lines, windows);
+}
+
+export function buildFullFileContext(file) {
+  const content = getFileContent(file);
+  return `### Full File Content (For Context - line numbers shown for reference):
+\`\`\`${file.language || ''}
+${addLineNumbers(content)}
+\`\`\``;
+}
+
+export function formatPlannedHolisticFileContext(file, plan, options = {}) {
+  if (plan.mode === 'full') {
+    return buildFullFileContext(file);
+  }
+
+  return buildFocusedFileContext(file, plan, options);
+}
+
+function setPlanCosts(plan, contextTokens) {
+  return {
+    ...plan,
+    contextTokens,
+    totalTokens: plan.diffTokens + contextTokens,
+  };
+}
+
+function assignPlanCosts(plan, contextTokens) {
+  plan.contextTokens = contextTokens;
+  plan.totalTokens = plan.diffTokens + contextTokens;
+}
+
+function estimatePlanContextTokens(file, plan, options = {}) {
+  if (plan.mode === 'full') {
+    return plan.fullContentTokens;
+  }
+
+  return estimatePrContextTokens(buildFocusedFileContext(file, plan, options));
+}
+
+function createInitialPlan(file, index, contextLineRadius) {
+  const fullContentTokens = estimatePrContextTokens(getFileContent(file));
+  const diffTokens = estimatePrContextTokens(file.diff || file.diffContent);
+  return {
+    index,
+    path: getFilePath(file, index),
+    mode: 'focused',
+    reason: '',
+    fullContentTokens,
+    diffTokens,
+    contextTokens: 0,
+    totalTokens: diffTokens,
+    contextLineRadius,
+  };
+}
+
+function planHolisticFileContexts(prFiles, options = {}) {
+  const maxTotalTokens = options.maxTotalFullContentTokens ?? DEFAULT_MAX_TOTAL_FULL_CONTENT_TOKENS;
+  const defaultSingleFileTokens = Math.max(
+    DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE,
+    Math.floor(maxTotalTokens * DEFAULT_MAX_SINGLE_FILE_BUDGET_SHARE)
+  );
+  const maxSingleFileTokens = options.maxSingleFullContentTokens ?? defaultSingleFileTokens;
+  const plans = prFiles.map((file, index) => createInitialPlan(file, index, DEFAULT_CONTEXT_LINE_RADIUS));
+
+  const eligiblePlans = plans
+    .filter((plan) => plan.fullContentTokens <= maxSingleFileTokens)
+    .sort((a, b) => {
+      // Diff-heavy files are more likely to need broad context; cap size influence so one giant file cannot dominate.
+      const scoreA = Math.min(a.fullContentTokens, DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE) + a.diffTokens * 2;
+      const scoreB = Math.min(b.fullContentTokens, DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE) + b.diffTokens * 2;
+      return scoreB - scoreA;
+    });
+  let remainingBudget = maxTotalTokens;
+
+  for (const plan of eligiblePlans) {
+    if (plan.fullContentTokens > remainingBudget) {
+      continue;
+    }
+
+    plan.mode = 'full';
+    plan.reason = 'full content fits holistic context budget';
+    assignPlanCosts(plan, plan.fullContentTokens);
+    remainingBudget -= plan.fullContentTokens;
+  }
+
+  for (const plan of plans) {
+    if (plan.mode === 'focused') {
+      if (plan.fullContentTokens > maxSingleFileTokens) {
+        plan.reason = `full content estimate ${plan.fullContentTokens} tokens exceeds per-file holistic context ceiling ${maxSingleFileTokens}`;
+      }
+      else {
+        plan.reason = `full content estimate ${plan.fullContentTokens} tokens was not selected within total holistic context budget ${maxTotalTokens}`;
+      }
+      const file = prFiles[plan.index];
+      assignPlanCosts(plan, estimatePlanContextTokens(file, plan, options));
+    }
+  }
+
+  return plans;
+}
+
+function getFullContentAllocation(plans) {
+  return plans.reduce((sum, plan) => {
+    if (plan?.mode !== 'full') {
+      return sum;
+    }
+
+    return sum + (plan.contextTokens || 0);
+  }, 0);
+}
+
+export function fileCost(plan) {
+  return plan?.totalTokens || 0;
+}
+
+export function diffCost(fileOrPlan) {
+  if (Number.isFinite(fileOrPlan?.diffTokens)) {
+    return fileOrPlan.diffTokens;
+  }
+
+  return estimatePrContextTokens(fileOrPlan?.diff || fileOrPlan?.diffContent);
+}
+
+export function rawFullContentCost(file) {
+  return estimatePrContextTokens(getFileContent(file));
+}
+
+export function planContextCost(plan) {
+  return plan?.contextTokens || 0;
+}
+
+export function fitHolisticPlanToChunk(file, plan, maxTotalTokens) {
+  const diffTokens = diffCost(file);
+
+  if (plan.mode !== 'focused') {
+    return setPlanCosts({ ...plan, diffTokens }, plan.contextTokens);
+  }
+
+  const contextBudget = Math.max(maxTotalTokens - diffTokens, 0);
+  const adjustedPlan = {
+    ...plan,
+    diffTokens,
+    maxFocusedContextTokens: contextBudget,
+    reason: contextBudget < plan.contextTokens ? `${plan.reason}; focused context reduced to fit chunk token budget` : plan.reason,
+  };
+  return setPlanCosts(adjustedPlan, estimatePlanContextTokens(file, adjustedPlan));
+}
+
+/**
+ * Merge existing holistic context plans with generated plans for files that are missing one.
+ *
+ * Existing full-content plans are counted against maxTotalFullContentTokens before
+ * planning missing files, so partial callers keep the same total full-content budget invariant.
+ *
+ * @param {Array<object>} prFiles - PR file metadata objects.
+ * @param {object} options - Context planning options.
+ * @param {number} [options.maxTotalFullContentTokens] - Total token budget for full-file context across all files.
+ * @param {number} [options.maxSingleFullContentTokens] - Hard per-file full-content eligibility ceiling.
+ * @param {Array<object>} existingPlans - Existing plans by PR file index.
+ * @returns {HolisticFileContextPlan[]} A plan for each PR file.
+ */
+export function mergeHolisticFileContextPlans(prFiles, options = {}, existingPlans = []) {
+  const plans = Array.isArray(existingPlans) ? [...existingPlans] : [];
+  const missingPlanIndexes = [];
+
+  prFiles.forEach((file, index) => {
+    if (file.holisticContextPlan) {
+      plans[index] = file.holisticContextPlan;
+    }
+
+    if (!plans[index]) {
+      missingPlanIndexes.push(index);
+    }
+  });
+
+  if (missingPlanIndexes.length === 0) {
+    return plans;
+  }
+
+  const maxTotalTokens = options.maxTotalFullContentTokens ?? DEFAULT_MAX_TOTAL_FULL_CONTENT_TOKENS;
+  const remainingFullContentBudget = Math.max(0, maxTotalTokens - getFullContentAllocation(plans));
+  const generatedPlans = planHolisticFileContexts(
+    missingPlanIndexes.map((index) => prFiles[index]),
+    { ...options, maxTotalFullContentTokens: remainingFullContentBudget }
+  );
+
+  missingPlanIndexes.forEach((index, generatedPlanIndex) => {
+    plans[index] = generatedPlans[generatedPlanIndex];
+  });
+
+  return plans;
+}

--- a/src/utils/pr-file-context.test.js
+++ b/src/utils/pr-file-context.test.js
@@ -1,0 +1,239 @@
+import {
+  buildFocusedFileContext,
+  estimatePrContextTokens,
+  formatPlannedHolisticFileContext,
+  mergeHolisticFileContextPlans,
+} from './pr-file-context.js';
+
+describe('mergeHolisticFileContextPlans', () => {
+  it('keeps complete file content when the PR fits the holistic context budget', () => {
+    const plans = mergeHolisticFileContextPlans([
+      { filePath: 'src/a.js', content: 'const a = 1;', diffContent: '+const a = 1;' },
+      { filePath: 'src/b.js', content: 'const b = 2;', diffContent: '+const b = 2;' },
+    ]);
+
+    expect(plans.map((plan) => plan.mode)).toEqual(['full', 'full']);
+  });
+
+  it('uses focused context for files that exceed the total full-content budget', () => {
+    const plans = mergeHolisticFileContextPlans([
+      { filePath: 'src/huge.js', content: 'x'.repeat(210000), diffContent: '+changed' },
+      { filePath: 'src/small.js', content: 'const ok = true;', diffContent: '+const ok = true;' },
+    ]);
+
+    expect(plans[0].mode).toBe('focused');
+    expect(plans[1].mode).toBe('full');
+  });
+
+  it('keeps a file above the per-file soft cap complete when total budget allows', () => {
+    const plans = mergeHolisticFileContextPlans([{ filePath: 'src/large.js', content: 'x'.repeat(45000), diffContent: '+changed' }]);
+
+    expect(plans[0].mode).toBe('full');
+  });
+
+  it('does not let one huge file consume almost the entire full-content budget', () => {
+    const plans = mergeHolisticFileContextPlans([
+      { filePath: 'src/huge.js', content: 'x'.repeat(174000), diffContent: '+important change'.repeat(50) },
+      { filePath: 'src/small.js', content: 'const ok = true;', diffContent: '+const ok = true;' },
+    ]);
+
+    expect(plans[0].mode).toBe('focused');
+    expect(plans[0].reason).toContain('per-file holistic context ceiling');
+    expect(plans[1].mode).toBe('full');
+  });
+
+  it('prioritizes larger changed files over trivial small files when the aggregate budget is tight', () => {
+    const plans = mergeHolisticFileContextPlans(
+      [
+        { filePath: 'src/large.js', content: 'a'.repeat(45), diffContent: '+important change'.repeat(10) },
+        { filePath: 'src/small-1.js', content: 'b'.repeat(15), diffContent: '+b' },
+        { filePath: 'src/small-2.js', content: 'c'.repeat(15), diffContent: '+c' },
+      ],
+      { maxSingleFullContentTokens: 100, maxTotalFullContentTokens: 20 }
+    );
+
+    expect(plans[0].mode).toBe('full');
+  });
+
+  it('reserves already allocated full-content budget when filling missing plans', () => {
+    const plans = mergeHolisticFileContextPlans(
+      [
+        { filePath: 'src/already-planned.js', content: 'a'.repeat(120), diffContent: '+a' },
+        { filePath: 'src/missing-large.js', content: 'b'.repeat(120), diffContent: '+b' },
+        { filePath: 'src/missing-small.js', content: 'c'.repeat(15), diffContent: '+c' },
+      ],
+      { maxTotalFullContentTokens: 50, maxSingleFullContentTokens: 50 },
+      [{ mode: 'full', fullContentTokens: 40, contextTokens: 40, totalTokens: 41 }]
+    );
+
+    expect(plans[0].mode).toBe('full');
+    expect(plans[1].mode).toBe('focused');
+    expect(plans[2].mode).toBe('full');
+  });
+});
+
+describe('formatPlannedHolisticFileContext', () => {
+  it('formats complete file context with line numbers', () => {
+    const file = { language: 'javascript', content: 'const a = 1;\nconst b = 2;' };
+    const rendered = formatPlannedHolisticFileContext(file, { mode: 'full' });
+
+    expect(rendered).toContain('Full File Content');
+    expect(rendered).toContain('const a = 1;');
+    expect(rendered).toContain('const b = 2;');
+  });
+
+  it('formats focused context around changed hunks', () => {
+    const content = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join('\n');
+    const file = {
+      language: 'javascript',
+      content,
+      diffContent: '@@ -10,1 +10,1 @@\n-line 10\n+line 10 changed',
+    };
+    const rendered = buildFocusedFileContext(
+      file,
+      { mode: 'focused', reason: 'test budget', fullContentTokens: 100, contextTokens: 10, totalTokens: 20 },
+      { contextLineRadius: 2 }
+    );
+
+    expect(rendered).toContain('Focused File Context');
+    expect(rendered).toContain('lines 8-12');
+    expect(rendered).toContain('10 | line 10');
+    expect(rendered).not.toContain('20 | line 20');
+  });
+
+  it('anchors added lines whose content starts with ++', () => {
+    const content = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: '@@ -10,0 +10,2 @@\n+++counter;\n+line 10 changed',
+      },
+      { mode: 'focused', reason: 'test budget' },
+      { contextLineRadius: 0 }
+    );
+
+    expect(rendered).toContain('lines 10-11');
+    expect(rendered).toContain('10 | line 10');
+    expect(rendered).toContain('11 | line 11');
+  });
+
+  it('anchors deletion-only hunks near the deleted region', () => {
+    const content = Array.from({ length: 200 }, (_, index) => `line ${index + 1}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: '@@ -150,2 +150,0 @@\n-line 150\n-line 151',
+      },
+      { mode: 'focused', reason: 'test budget' },
+      { contextLineRadius: 2 }
+    );
+
+    expect(rendered).toContain('lines 148-152');
+    expect(rendered).toContain('150 | line 150');
+    expect(rendered).not.toMatch(/\n\s*1 \| line 1\n/);
+  });
+
+  it('clamps deletion-only anchors that point beyond the available file content', () => {
+    const content = Array.from({ length: 7 }, (_, index) => `line ${index + 1}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: '@@ -50,5 +50,0 @@\n-line 50\n-line 51',
+      },
+      { mode: 'focused', reason: 'test budget' },
+      { contextLineRadius: 40 }
+    );
+
+    expect(rendered).toContain('lines 1-7');
+    expect(rendered).toContain('7 | line 7');
+    expect(rendered).not.toContain('lines 10-7');
+    expect(rendered).not.toContain('Included -');
+  });
+
+  it('renders focused context from the current file instead of a cached plan copy', () => {
+    const plan = { mode: 'focused', reason: 'test budget' };
+    const file = {
+      language: 'javascript',
+      content: 'line 1\nline 2',
+      diffContent: '@@ -2,1 +2,1 @@\n-line 2\n+line 2 changed',
+    };
+
+    buildFocusedFileContext(file, plan);
+    const secondRender = buildFocusedFileContext({ ...file, content: 'different 1\ndifferent 2' }, plan);
+
+    expect(secondRender).toContain('different 2');
+    expect(secondRender).not.toContain('line 2');
+  });
+
+  it('shrinks a focused window to fit the remaining context budget instead of dropping it', () => {
+    const content = Array.from({ length: 200 }, (_, index) => `line ${index + 1} ${'x'.repeat(35)}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: '@@ -100,1 +100,1 @@\n-line 100\n+line 100 changed',
+      },
+      { mode: 'focused', reason: 'chunk budget', maxFocusedContextTokens: 500 },
+      { contextLineRadius: 40 }
+    );
+
+    expect(rendered).toContain('100 | line 100');
+    expect(rendered).not.toContain('No focused file context windows fit');
+    expect(rendered).not.toContain('lines 60-140');
+  });
+
+  it('keeps minimal context for distant change sites when budget is tight', () => {
+    const content = Array.from({ length: 2000 }, (_, index) => `line ${index + 1} ${'x'.repeat(20)}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: '@@ -10,1 +10,1 @@\n-line 10\n+line 10 changed\n@@ -1990,1 +1990,1 @@\n-line 1990\n+line 1990 changed',
+      },
+      { mode: 'focused', reason: 'chunk budget', maxFocusedContextTokens: 700 },
+      { contextLineRadius: 40 }
+    );
+
+    expect(rendered).toContain('10 | line 10');
+    expect(rendered).toContain('1990 | line 1990');
+    expect(rendered).not.toContain('No focused file context windows fit');
+  });
+
+  it('validates selected focused windows against the actual rendered markdown budget', () => {
+    const content = Array.from({ length: 1200 }, (_, index) => `line ${index + 1}`).join('\n');
+    const diffContent = Array.from(
+      { length: 1200 },
+      (_, index) => `@@ -${index + 1},1 +${index + 1},1 @@\n-line ${index + 1}\n+line ${index + 1} changed`
+    ).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent,
+      },
+      { mode: 'focused', reason: 'chunk budget', maxFocusedContextTokens: 9500 },
+      { contextLineRadius: 0 }
+    );
+
+    expect(estimatePrContextTokens(rendered)).toBeLessThanOrEqual(9500);
+  });
+
+  it('keeps anchorless fallback context within the focused context budget', () => {
+    const content = Array.from({ length: 200 }, (_, index) => `line ${index + 1} ${'x'.repeat(30)}`).join('\n');
+    const rendered = buildFocusedFileContext(
+      {
+        language: 'javascript',
+        content,
+        diffContent: 'mode change only',
+      },
+      { mode: 'focused', reason: 'chunk budget', maxFocusedContextTokens: 0 },
+      { contextLineRadius: 40 }
+    );
+
+    expect(rendered).toContain('No focused file context windows fit');
+    expect(rendered).not.toContain('1 | line 1');
+  });
+});


### PR DESCRIPTION
This PR right-sizes holistic PR review context so small reviews keep full-file awareness while large files and large PRs stay within token budgets.

- Adds a shared git diff line parser used by review context planning and changed-line detection.
- Introduces adaptive holistic file context plans with full-file and focused-window modes.
- Uses plan-owned context and total token costs so chunking estimates match rendered prompt context.
- Caps focused context for chunked reviews without mutating planner internals in chunking.
- Preserves relevant hunk anchors for split diff chunks and avoids duplicated full-file context across chunks.
- Adds regression coverage for deletion-only hunks, split hunks, focused-window budgeting, and plan reuse.
