### PR TITLE
fix: address review findings from PRs #73-#76

### DIFF
--- a/src/embeddings/database.js
+++ b/src/embeddings/database.js
@@ -26,7 +26,7 @@ import chalk from 'chalk';
 import { getTableSchema, schemaHasField } from '../utils/lancedb.js';
 import { debug, verboseLog } from '../utils/logging.js';
 import { isPathWithinProject } from '../utils/path-utils.js';
-import { escapeSqlString } from '../utils/string-utils.js';
+import { buildIdInFilter, escapeSqlString } from '../utils/string-utils.js';
 import { EMBEDDING_DIMENSIONS, TABLE_NAMES } from './constants.js';
 import { LANCEDB_PATH } from './constants.js';
 import { createDatabaseError, ERROR_CODES } from './errors.js';
@@ -41,10 +41,6 @@ const DOCUMENT_CHUNK_TABLE = TABLE_NAMES.DOCUMENT_CHUNK;
 const PR_COMMENTS_TABLE = TABLE_NAMES.PR_COMMENTS;
 const PROJECT_SUMMARIES_TABLE = TABLE_NAMES.PROJECT_SUMMARIES;
 const DELETE_BATCH_SIZE = 100;
-
-function buildIdInFilter(ids) {
-  return `id IN (${ids.map((id) => `'${escapeSqlString(id)}'`).join(', ')})`;
-}
 
 async function deleteRecordsById(table, records, warningMessage) {
   let deletedCount = 0;
@@ -693,23 +689,16 @@ export class DatabaseManager {
       .query()
       .where(`project_path = '${escapeSqlString(resolvedProjectPath)}'`)
       .toArray();
-    let deletedCount = 0;
 
-    for (const record of records) {
-      if (!record.original_document_path || liveDocumentPathSet.has(record.original_document_path)) {
-        continue;
-      }
+    const recordsToDelete = records.filter(
+      (record) => record.original_document_path && !liveDocumentPathSet.has(record.original_document_path)
+    );
 
-      try {
-        await table.delete(`id = '${escapeSqlString(record.id)}'`);
-        deletedCount++;
-      }
-      catch (deleteError) {
-        console.warn(chalk.yellow(`Warning: Could not prune document chunk ${record.id}: ${deleteError.message}`));
-      }
-    }
-
-    return deletedCount;
+    return deleteRecordsById(
+      table,
+      recordsToDelete,
+      (record, deleteError) => `Warning: Could not prune document chunk ${record.id}: ${deleteError.message}`
+    );
   }
 
   // ============================================================================

--- a/src/embeddings/file-processor.js
+++ b/src/embeddings/file-processor.js
@@ -21,7 +21,7 @@ import { isDocumentationFile, shouldProcessFile as utilsShouldProcessFile, batch
 import { detectLanguageFromExtension } from '../utils/language-detection.js';
 import { debug, verboseLog } from '../utils/logging.js';
 import { extractMarkdownChunks } from '../utils/markdown.js';
-import { escapeSqlString, slugify } from '../utils/string-utils.js';
+import { buildIdInFilter, escapeSqlString, slugify } from '../utils/string-utils.js';
 import { TABLE_NAMES, LANCEDB_DIR_NAME, FASTEMBED_CACHE_DIR_NAME } from './constants.js';
 import { createFileProcessingError } from './errors.js';
 
@@ -46,10 +46,6 @@ function buildExistingDocumentSignature(chunks) {
     .map((chunk) => `${chunk.id}:${chunk.content_hash}`)
     .sort()
     .join('|');
-}
-
-function buildIdInFilter(ids) {
-  return `id IN (${ids.map((id) => `'${escapeSqlString(id)}'`).join(', ')})`;
 }
 
 async function deleteFileEmbeddingRecords(table, records) {

--- a/src/project-analyzer.js
+++ b/src/project-analyzer.js
@@ -405,8 +405,25 @@ export class ProjectAnalyzer {
               return depthA - depthB;
             });
 
-            // Take only the first 500 after sorting to ensure we have shallow files
-            const sortedFiles = allFiles.slice(0, TERM_SEARCH_CONTENT_CANDIDATE_LIMIT);
+            // Dedupe by path before capping: transient duplicate rows can exist for
+            // the same file (different content_hash) when a partial run hasn't pruned
+            // stale embeddings, and they would otherwise consume candidate slots and
+            // bloat the content query. Keep the shallowest occurrence (allFiles is
+            // already depth-sorted), then take the first 500 distinct shallow files.
+            const seenPaths = new Set();
+            const sortedFiles = [];
+            for (const file of allFiles) {
+              if (file.path) {
+                if (seenPaths.has(file.path)) {
+                  continue;
+                }
+                seenPaths.add(file.path);
+              }
+              sortedFiles.push(file);
+              if (sortedFiles.length >= TERM_SEARCH_CONTENT_CANDIDATE_LIMIT) {
+                break;
+              }
+            }
             if (sortedFiles.length === 0) {
               return [];
             }
@@ -415,14 +432,20 @@ export class ProjectAnalyzer {
             const contentByPath = new Map();
             if (candidatePaths.length > 0) {
               const pathList = candidatePaths.map((candidatePath) => `'${escapeSqlString(candidatePath)}'`).join(', ');
+              // No row limit here: the result set is already bounded by the IN list of
+              // distinct candidate paths. A limit could truncate rows when duplicate
+              // rows exist for a path, silently dropping content for matched files.
               const contentResults = await table
                 .query()
                 .select(['path', 'content'])
                 .where(`${projectPathFilter} AND path IN (${pathList})`)
-                .limit(TERM_SEARCH_CONTENT_CANDIDATE_LIMIT)
                 .toArray();
 
               for (const result of contentResults) {
+                // Prefer non-empty content when duplicate rows exist for a path.
+                if (contentByPath.get(result.path)) {
+                  continue;
+                }
                 contentByPath.set(result.path, result.content || '');
               }
             }

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -471,8 +471,10 @@ async function runAnalysis(filePath, options = {}) {
     let fullFileContent;
     if (options.diffOnly && options.diffContent) {
       content = options.diffContent;
-      // For PR reviews, always read the full file content for context awareness
-      fullFileContent = await readTextFile(filePath);
+      // For PR reviews, always read the full file content for context awareness.
+      // Tolerate a missing/unreadable file (e.g. deleted in the window after the
+      // existence check) by degrading to null; downstream falls back to file.content.
+      fullFileContent = await readTextFile(filePath).catch(() => null);
       verboseLog(options, chalk.blue(`Analyzing diff only for ${path.basename(filePath)}`));
     }
     else {

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -875,6 +875,22 @@ ${projectArchitectureSection}`);
   return blocks;
 }
 
+/**
+ * Build the user-prompt sentence that points the model at the cached system blocks.
+ * Returns an empty string when no cached blocks were emitted, so the prompt never
+ * instructs the model to use context that was not sent.
+ *
+ * @param {string[]} cachedSystemBlocks - Cached blocks produced for this request
+ * @param {string} subject - What is being evaluated (e.g. 'this file')
+ * @returns {string} Instruction sentence, or '' when there is no cached context
+ */
+function buildCachedContextInstruction(cachedSystemBlocks, subject) {
+  if (!cachedSystemBlocks || cachedSystemBlocks.length === 0) {
+    return '';
+  }
+  return `Use the cached project context, project architecture, and custom instructions when evaluating ${subject}.`;
+}
+
 // LLM call function - sends prompt with cached system content for cost optimization
 async function sendPromptToLLM(promptConfig, llmOptions) {
   try {
@@ -1152,7 +1168,7 @@ ${reviewInstructions}
 
 ${fileSection}
 
-Use the cached project context, project architecture, and custom instructions when evaluating this file.
+${buildCachedContextInstruction(cachedSystemBlocks, 'this file')}
 
 CONTEXT A: EXPLICIT GUIDELINES FROM DOCUMENTATION
 ${formattedGuidelines}
@@ -1272,7 +1288,7 @@ ${reviewInstructions}
 ${fileSection}
 
 ## ANALYSIS CONTEXT
-Use the cached project context, project architecture, and custom instructions when evaluating this test file.
+${buildCachedContextInstruction(cachedSystemBlocks, 'this test file')}
 
 CONTEXT A: TESTING GUIDELINES AND BEST PRACTICES
 ${formattedGuidelines}
@@ -1429,7 +1445,7 @@ For each file in this PR, you have access to:
 - **Test Files**: ${prFiles.filter((f) => f.isTest).length}
 
 ## UNIFIED CONTEXT FROM PROJECT
-Use the cached project context, project architecture, and custom instructions when evaluating this pull request.
+${buildCachedContextInstruction(cachedSystemBlocks, 'this pull request')}
 
 ### PROJECT CODE EXAMPLES
 ${formattedCodeExamples}

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -65,3 +65,13 @@ export function addLineNumbers(content) {
 export function escapeSqlString(value) {
   return String(value).replace(/'/g, "''");
 }
+
+/**
+ * Build a SQL `id IN (...)` filter from a list of record ids, escaping each value.
+ *
+ * @param {string[]} ids - Record ids to include in the filter
+ * @returns {string} SQL predicate of the form `id IN ('a', 'b', ...)`
+ */
+export function buildIdInFilter(ids) {
+  return `id IN (${ids.map((id) => `'${escapeSqlString(id)}'`).join(', ')})`;
+}


### PR DESCRIPTION
Follow-up fixes from PRs (#73–#76):

- **#73 — `fix(project-analyzer)`: term-search content loss.** Dedupe term-search candidates by path before the 500-file cap and drop the content-query row limit (the `IN` list already bounds the result set). Transient duplicate embedding rows for a path can no longer truncate the content fetch or stale-overwrite a matched file's content; non-empty content is preferred when duplicates exist.
- **#76 — `fix(review)`: graceful read fallback.** Restore the pre-existing `null` fallback so a file deleted in the window after the existence check no longer aborts the whole analysis on the diff-only path; downstream already falls back to `file.content`.
- **#74 — `fix(prompts)`: conditional cached-context instruction.** New `buildCachedContextInstruction` so the user prompt no longer tells the model to use cached project context when no cached system blocks were produced (e.g. no project summary or custom docs).

## Cleanup

- **#75 — `refactor(embeddings)`:** `pruneProjectDocumentChunks` reuses the batched `deleteRecordsById` helper, and the duplicated `buildIdInFilter` is hoisted into `utils/string-utils.js`.