### PR TITLE
Lazy-load embeddings system

### DIFF
--- a/src/embeddings/factory.js
+++ b/src/embeddings/factory.js
@@ -460,3 +460,11 @@ export function getDefaultEmbeddingsSystem() {
   }
   return defaultSystem;
 }
+
+/**
+ * Get the default singleton instance only if it has already been created.
+ * @returns {EmbeddingsSystem|null}
+ */
+export function getDefaultEmbeddingsSystemIfInitialized() {
+  return defaultSystem;
+}

--- a/src/embeddings/factory.test.js
+++ b/src/embeddings/factory.test.js
@@ -1,4 +1,4 @@
-import { getDefaultEmbeddingsSystem } from './factory.js';
+import { getDefaultEmbeddingsSystem, getDefaultEmbeddingsSystemIfInitialized } from './factory.js';
 
 vi.mock('./cache-manager.js', () => ({
   CacheManager: class {
@@ -80,6 +80,10 @@ describe('EmbeddingsSystem', () => {
       const system1 = getDefaultEmbeddingsSystem();
       const system2 = getDefaultEmbeddingsSystem();
       expect(system1).toBe(system2);
+    });
+
+    it('should expose the created singleton without creating a new one', () => {
+      expect(getDefaultEmbeddingsSystemIfInitialized()).toBe(system);
     });
 
     it('should create system with all components', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import chalk from 'chalk';
 import { Spinner } from 'cli-spinner';
 import { program } from 'commander';
 import { glob } from 'glob';
-import { getDefaultEmbeddingsSystem } from './embeddings/factory.js';
+import { getDefaultEmbeddingsSystem, getDefaultEmbeddingsSystemIfInitialized } from './embeddings/factory.js';
 import { PRHistoryAnalyzer } from './pr-history/analyzer.js';
 import {
   displayAnalysisResults,
@@ -34,8 +34,12 @@ import { diagnosticLog, isDebugEnabled, isVerboseEnabled, verboseLog } from './u
 import { collectPRLevelFindings, getFileLevelIssueCount, hasPRLevelFindings } from './utils/review-results.js';
 import { configureCleanStdoutForDataOutput, isBrokenStdoutPipeError, writeStdout } from './utils/stdout.js';
 
-// Create a default embeddings system instance
-const embeddingsSystem = getDefaultEmbeddingsSystem();
+async function cleanupEmbeddingsSystemIfInitialized() {
+  const embeddingsSystem = getDefaultEmbeddingsSystemIfInitialized();
+  if (embeddingsSystem) {
+    await embeddingsSystem.cleanup();
+  }
+}
 
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
@@ -103,6 +107,7 @@ program
   .command('embeddings:clear-all')
   .description('Clear ALL stored embeddings (affects all projects - use with caution)')
   .action(async () => {
+    const embeddingsSystem = getDefaultEmbeddingsSystem();
     try {
       console.log(chalk.red('WARNING: This will clear embeddings for ALL projects on this machine!'));
       console.log(chalk.cyan('Clearing all embeddings...'));
@@ -227,7 +232,7 @@ process.on('SIGINT', async () => {
 
   try {
     diagnosticLog(chalk.cyan('SIGINT handler: Attempting embeddingsSystem.cleanup()...'));
-    await embeddingsSystem.cleanup();
+    await cleanupEmbeddingsSystemIfInitialized();
     diagnosticLog(chalk.green('embeddingsSystem.cleanup() completed.'));
     clearTimeout(forceExitTimeout); // Cleanup finished, clear the timeout
     diagnosticLog(chalk.cyan('SIGINT handler: Exiting normally (code 0).'));
@@ -251,7 +256,7 @@ process.on('SIGTERM', async () => {
 
   try {
     diagnosticLog(chalk.cyan('SIGTERM handler: Attempting embeddingsSystem.cleanup()...'));
-    await embeddingsSystem.cleanup();
+    await cleanupEmbeddingsSystemIfInitialized();
     diagnosticLog(chalk.green('embeddingsSystem.cleanup() completed.'));
     clearTimeout(forceExitTimeout); // Cleanup finished, clear the timeout
     diagnosticLog(chalk.cyan('SIGTERM handler: Exiting normally (code 0).'));
@@ -468,7 +473,7 @@ async function runCodeReview(options) {
     // Clean up resources
     diagnosticLog(chalk.cyan('Cleaning up resources...'));
     try {
-      await embeddingsSystem.cleanup();
+      await cleanupEmbeddingsSystemIfInitialized();
       await cleanupClassifier();
       diagnosticLog(chalk.green('All resources cleaned up successfully'));
     }
@@ -497,7 +502,7 @@ async function runCodeReview(options) {
 
     // Clean up resources even on error
     try {
-      await embeddingsSystem.cleanup();
+      await cleanupEmbeddingsSystemIfInitialized();
       await cleanupClassifier();
       diagnosticLog(chalk.green('All resources cleaned up successfully'));
     }
@@ -516,6 +521,7 @@ async function runCodeReview(options) {
  * @param {Object} options - Command options
  */
 async function generateEmbeddings(options) {
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
   try {
     console.log(chalk.bold.blue('AI Code Review - Generating embeddings...'));
     const startTime = Date.now();
@@ -717,6 +723,7 @@ async function generateEmbeddings(options) {
  * Clear stored embeddings for the current project
  */
 async function clearEmbeddings(options) {
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
   try {
     // Determine the working directory for project separation
     // If --directory is specified, use that as the project directory
@@ -751,6 +758,7 @@ async function clearEmbeddings(options) {
  * Show statistics about stored embeddings
  */
 async function showEmbeddingStats(options) {
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
   try {
     // Determine the working directory for project separation
     // If --directory is specified, use that as the project directory

--- a/src/pr-history/comment-processor.js
+++ b/src/pr-history/comment-processor.js
@@ -9,9 +9,6 @@ import chalk from 'chalk';
 import { getDefaultEmbeddingsSystem } from '../embeddings/factory.js';
 import { filterBotComments } from './bot-detector.js';
 
-// Create embeddings system instance
-const embeddingsSystem = getDefaultEmbeddingsSystem();
-
 export class PRCommentProcessor {
   constructor() {
     // Classification patterns for different issue categories
@@ -335,7 +332,7 @@ export class PRCommentProcessor {
    * @returns {Promise<Array<number>>} Comment embedding
    */
   async generateCommentEmbedding(text) {
-    const embedding = await embeddingsSystem.calculateEmbedding(text);
+    const embedding = await getDefaultEmbeddingsSystem().calculateEmbedding(text);
     if (!embedding || embedding.length !== 384) {
       throw new Error(`Invalid embedding dimensions: expected 384, got ${embedding?.length}`);
     }
@@ -348,7 +345,7 @@ export class PRCommentProcessor {
    * @returns {Promise<Array<number>>} Code embedding
    */
   async generateCodeEmbedding(code) {
-    const embedding = await embeddingsSystem.calculateEmbedding(code);
+    const embedding = await getDefaultEmbeddingsSystem().calculateEmbedding(code);
     if (!embedding || embedding.length !== 384) {
       throw new Error(`Invalid embedding dimensions: expected 384, got ${embedding?.length}`);
     }
@@ -370,7 +367,7 @@ export class PRCommentProcessor {
     const combinedText = [commentText, codeText].filter(Boolean).join('\n\n--- CODE CONTEXT ---\n\n');
 
     // Generate embedding from the concatenated text
-    const combinedEmbedding = await embeddingsSystem.calculateEmbedding(combinedText);
+    const combinedEmbedding = await getDefaultEmbeddingsSystem().calculateEmbedding(combinedText);
     if (!combinedEmbedding || combinedEmbedding.length !== 384) {
       throw new Error(`Invalid combined embedding dimensions: expected 384, got ${combinedEmbedding?.length}`);
     }

--- a/src/pr-history/database.js
+++ b/src/pr-history/database.js
@@ -16,9 +16,6 @@ import { verboseLog } from '../utils/logging.js';
 import { truncateToTokenLimit, cleanupTokenizer } from '../utils/mobilebert-tokenizer.js';
 import { escapeSqlString } from '../utils/string-utils.js';
 
-// Create embeddings system instance
-const embeddingsSystem = getDefaultEmbeddingsSystem();
-
 // Import constants from embeddings.js to avoid duplication
 const { PR_COMMENTS } = TABLE_NAMES;
 const PR_COMMENTS_TABLE = PR_COMMENTS;
@@ -47,7 +44,7 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
   const liveIdsByPR = collectLiveCommentIdsByPR(sourceComments, replacePRs);
 
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     if (!table) {
       throw new Error(`Table ${PR_COMMENTS_TABLE} not found`);
@@ -139,7 +136,7 @@ export async function storePRCommentsBatch(commentsData, projectPath = process.c
 
     if (successCount > 0 || staleCleanupAttempted) {
       await optimizePRCommentsTable(table);
-      await embeddingsSystem.updatePRCommentsIndex();
+      await getDefaultEmbeddingsSystem().updatePRCommentsIndex();
     }
   }
   catch (error) {
@@ -296,7 +293,7 @@ function getPRStorageKey(repository, prNumber) {
  */
 export async function getPRCommentsStats(repository = null, projectPath = process.cwd()) {
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     const defaultStats = {
       total_comments: 0,
@@ -442,7 +439,7 @@ export async function getPRCommentsStats(repository = null, projectPath = proces
  */
 export async function getProcessedPRSyncState(repository, projectPath = process.cwd()) {
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     if (!table) {
       return { processedPRs: new Map() };
@@ -543,7 +540,7 @@ export function shouldSkipPR(pr, processedPRSyncState) {
  */
 export async function clearPRComments(repository, projectPath = process.cwd()) {
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     if (!table) {
       return 0;
@@ -572,7 +569,7 @@ export async function clearPRComments(repository, projectPath = process.cwd()) {
  */
 export async function hasPRComments(repository, projectPath = process.cwd()) {
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     if (!table) {
       return false;
@@ -602,7 +599,7 @@ export async function hasPRComments(repository, projectPath = process.cwd()) {
  */
 export async function getLastAnalysisTimestamp(repository, projectPath) {
   try {
-    const table = await embeddingsSystem.getPRCommentsTable();
+    const table = await getDefaultEmbeddingsSystem().getPRCommentsTable();
 
     if (!table) {
       return null;
@@ -908,13 +905,13 @@ export async function findRelevantPRComments(reviewFileContent, options = {}) {
 
     const chunkEmbeddings = await Promise.all(
       codeChunks.map(async (chunk) => ({
-        vector: await embeddingsSystem.calculateQueryEmbedding(chunk.code),
+        vector: await getDefaultEmbeddingsSystem().calculateQueryEmbedding(chunk.code),
         ...chunk,
       }))
     );
 
     // --- Step 2: Search for relevant historical comments for each chunk ---
-    const mainTable = await embeddingsSystem.getPRCommentsTable();
+    const mainTable = await getDefaultEmbeddingsSystem().getPRCommentsTable();
     if (!mainTable) {
       throw new Error('Main PR comments table not found.');
     }

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -37,9 +37,6 @@ const DEFAULT_TRUNCATE_LINES = 300;
 const GUIDELINE_TRUNCATE_LINES = 400;
 const MAX_PR_COMMENTS_FOR_CONTEXT = 15;
 
-// Create embeddings system instance
-const embeddingsSystem = getDefaultEmbeddingsSystem();
-
 // Track if semantic similarity has been initialized
 let semanticSimilarityInitialized = false;
 
@@ -234,6 +231,7 @@ ${ex.content}
  */
 async function getProjectSummary(projectPath, options = {}) {
   const resolvedPath = path.resolve(projectPath);
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
 
   try {
     // Retrieve from database
@@ -1929,6 +1927,7 @@ async function performHolisticPRAnalysis(options) {
  * @returns {Promise<Object>} An object containing the gathered context.
  */
 async function getContextForFile(filePath, content, options = {}) {
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
   const RELEVANT_CHUNK_THRESHOLD = 0.1;
   const W_H1_SIM = 0.2;
   const W_DOC_CONTEXT_MATCH = 0.6;
@@ -2283,6 +2282,7 @@ async function getContextForFile(filePath, content, options = {}) {
 }
 
 async function gatherUnifiedContextForPR(prFiles, options = {}) {
+  const embeddingsSystem = getDefaultEmbeddingsSystem();
   const allProcessedContext = {
     codeExamples: new Map(),
     guidelines: new Map(),


### PR DESCRIPTION
This PR defers embeddings system creation so lightweight CLI commands do not pay the startup cost.

- Adds a non-creating factory accessor for cleanup paths.
- Moves embeddings singleton access into command and analysis paths that actually need it.
- Keeps --help and --version from initializing embeddings while preserving cleanup for initialized runs.