### PR TITLE
Load .env values safely in the shell wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ For easier integration with non-JavaScript projects, you can use the provided sh
    - Validates Node.js 24+ requirement
    - Provides helpful error messages for missing dependencies
 
+   The wrapper forwards only `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_LOG`, `GITHUB_TOKEN`, `GH_TOKEN`, `DEBUG`, `VERBOSE`, `CI`, and `GITHUB_WORKSPACE_PATH` from `.env`; other entries, including process-control variables such as `NODE_OPTIONS` and `PATH`, are ignored. An unreadable `.env` stops the wrapper with an error. Run it only in trusted project directories: `ANTHROPIC_BASE_URL` controls where API requests are sent.
+
 ## Quick Start
 
 Follow this three-step workflow for optimal code review results:

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ For easier integration with non-JavaScript projects, you can use the provided sh
    - Validates Node.js 24+ requirement
    - Provides helpful error messages for missing dependencies
 
-   The wrapper forwards only `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_LOG`, `GITHUB_TOKEN`, `GH_TOKEN`, `DEBUG`, `VERBOSE`, `CI`, and `GITHUB_WORKSPACE_PATH` from `.env`; other entries, including process-control variables such as `NODE_OPTIONS` and `PATH`, are ignored. An unreadable `.env` stops the wrapper with an error. Run it only in trusted project directories: `ANTHROPIC_BASE_URL` controls where API requests are sent.
+   The wrapper forwards only `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_LOG`, `GITHUB_TOKEN`, `GH_TOKEN`, `DEBUG`, `VERBOSE`, `CI`, and `GITHUB_WORKSPACE_PATH` from `.env`; other entries, including process-control variables such as `NODE_OPTIONS` and `PATH`, are ignored. An unreadable `.env` stops the wrapper with an error. Run it only in trusted project directories: `ANTHROPIC_BASE_URL` controls where API requests are sent, while `CI` and `GITHUB_WORKSPACE_PATH` control where embedding data is stored.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ DEBUG=true
 VERBOSE=true
 ```
 
+Set `CODECRITIQUE_SKIP_DOTENV=1` to disable `.env` loading, as the shell wrapper does after forwarding its supported variables.
+
 ## Output Formats
 
 CodeCritique supports three output formats:

--- a/src/codecritique.sh
+++ b/src/codecritique.sh
@@ -10,32 +10,42 @@ if ! command -v node &> /dev/null; then
     exit 1
 fi
 
-# Check if .env file exists in the current directory
-if [ -f .env ]; then
-    echo "Found .env file in current directory. Loading environment variables..."
-    # Export all variables from .env file
-    export $(grep -v '^#' .env | xargs)
-fi
-
-# Check if required API key is set
-if [ -z "$ANTHROPIC_API_KEY" ]; then
-    echo "Warning: ANTHROPIC_API_KEY is not set."
-    echo "You can set it by:"
-    echo "1. Creating a .env file in this directory with:"
-    echo "   ANTHROPIC_API_KEY=your_anthropic_api_key"
-    echo "2. Or by setting it as an environment variable before running this script:"
-    echo "   ANTHROPIC_API_KEY=your_key ./codecritique.sh ..."
-    echo ""
-    echo "Continuing anyway, as you may have set it in your environment..."
-    echo ""
-fi
-
-# Check if codecritique is installed globally
-if command -v codecritique &> /dev/null; then
-    # Run the command with all arguments passed to this script
-    codecritique "$@"
-else
-    # Try to run with npx if not installed globally
-    echo "codecritique not found globally, trying with npx..."
-    npx codecritique "$@"
-fi
+# Parse only CodeCritique-supported settings so a project .env cannot inject
+# process-control options such as NODE_OPTIONS or PATH into the child command.
+exec node -e '
+  const { spawnSync } = require("node:child_process");
+  const { readFileSync } = require("node:fs");
+  const { parseEnv } = require("node:util");
+  const args = process.argv.slice(1);
+  const supportedKeys = [
+    "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_LOG",
+    "GITHUB_TOKEN", "GH_TOKEN", "DEBUG", "VERBOSE"
+  ];
+  let fileEnv = {};
+  try {
+    fileEnv = parseEnv(readFileSync(".env", "utf8"));
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.error(`Unable to load .env: ${error.message}`);
+      process.exit(1);
+    }
+  }
+  const env = { ...process.env };
+  for (const key of supportedKeys) {
+    if (Object.hasOwn(fileEnv, key)) env[key] = fileEnv[key];
+  }
+  if (!env.ANTHROPIC_API_KEY) {
+    console.warn("Warning: ANTHROPIC_API_KEY is not set. Add it to .env or export it before running CodeCritique.");
+  }
+  let result = spawnSync("codecritique", args, { stdio: "inherit", env });
+  if (result.error?.code === "ENOENT") {
+    console.log("codecritique not found globally, trying with npx...");
+    result = spawnSync("npx", ["codecritique", ...args], { stdio: "inherit", env });
+  }
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  if (result.signal) process.exit(128 + require("node:os").constants.signals[result.signal]);
+  process.exit(result.status ?? 1);
+' -- "$@"

--- a/src/codecritique.sh
+++ b/src/codecritique.sh
@@ -11,6 +11,10 @@ if ! command -v node &> /dev/null; then
 fi
 
 node_major_version=$(node -p 'process.versions.node.split(".")[0]')
+if ! [[ "$node_major_version" =~ ^[0-9]+$ ]]; then
+    echo "Error: Unable to determine the Node.js major version (received: $node_major_version)." >&2
+    exit 1
+fi
 if [ "$node_major_version" -lt 24 ]; then
     echo "Error: CodeCritique requires Node.js 24 or newer (found $(node --version))." >&2
     exit 1
@@ -41,6 +45,7 @@ exec node -e '
       process.exit(1);
     }
   }
+  process.env.CODECRITIQUE_SKIP_DOTENV = "1";
   if (!process.env.ANTHROPIC_API_KEY) {
     console.warn("Warning: ANTHROPIC_API_KEY is not set. Add it to .env or export it before running CodeCritique.");
   }

--- a/src/codecritique.sh
+++ b/src/codecritique.sh
@@ -10,6 +10,12 @@ if ! command -v node &> /dev/null; then
     exit 1
 fi
 
+node_major_version=$(node -p 'process.versions.node.split(".")[0]')
+if [ "$node_major_version" -lt 24 ]; then
+    echo "Error: CodeCritique requires Node.js 24 or newer (found $(node --version))." >&2
+    exit 1
+fi
+
 # Parse only CodeCritique-supported settings so a project .env cannot inject
 # process-control options such as NODE_OPTIONS or PATH into the child command.
 exec node -e '
@@ -19,28 +25,29 @@ exec node -e '
   const args = process.argv.slice(1);
   const supportedKeys = [
     "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_LOG",
-    "GITHUB_TOKEN", "GH_TOKEN", "DEBUG", "VERBOSE"
+    "GITHUB_TOKEN", "GH_TOKEN", "DEBUG", "VERBOSE",
+    "CI", "GITHUB_WORKSPACE_PATH"
   ];
-  let fileEnv = {};
   try {
-    fileEnv = parseEnv(readFileSync(".env", "utf8"));
+    const fileEnv = parseEnv(readFileSync(".env", "utf8"));
+    for (const key of supportedKeys) {
+      if (!Object.hasOwn(fileEnv, key)) continue;
+      if (fileEnv[key].includes("\0")) throw new Error(`${key} contains a null byte`);
+      process.env[key] = fileEnv[key];
+    }
   } catch (error) {
     if (error.code !== "ENOENT") {
       console.error(`Unable to load .env: ${error.message}`);
       process.exit(1);
     }
   }
-  const env = { ...process.env };
-  for (const key of supportedKeys) {
-    if (Object.hasOwn(fileEnv, key)) env[key] = fileEnv[key];
-  }
-  if (!env.ANTHROPIC_API_KEY) {
+  if (!process.env.ANTHROPIC_API_KEY) {
     console.warn("Warning: ANTHROPIC_API_KEY is not set. Add it to .env or export it before running CodeCritique.");
   }
-  let result = spawnSync("codecritique", args, { stdio: "inherit", env });
+  let result = spawnSync("codecritique", args, { stdio: "inherit" });
   if (result.error?.code === "ENOENT") {
     console.log("codecritique not found globally, trying with npx...");
-    result = spawnSync("npx", ["codecritique", ...args], { stdio: "inherit", env });
+    result = spawnSync("npx", ["codecritique", ...args], { stdio: "inherit" });
   }
   if (result.error) {
     console.error(result.error.message);

--- a/src/codecritique.test.js
+++ b/src/codecritique.test.js
@@ -11,6 +11,7 @@ async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv
   const directory = await mkdtemp(join(tmpdir(), 'codecritique-shell-'));
   onTestFinished(() => rm(directory, { recursive: true, force: true }));
   const fakeCommand = join(directory, command);
+  const envInspector = join(directory, 'inspect-entry-env.mjs');
 
   if (envIsDirectory) {
     await mkdir(join(directory, '.env'));
@@ -18,7 +19,23 @@ async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv
   else if (envFile !== null) {
     await writeFile(join(directory, '.env'), envFile);
   }
-  await writeFile(fakeCommand, '#!/bin/bash\n[ "$1" = "--terminate" ] && kill -TERM $$\n/usr/bin/env\nprintf "arg=%s\\n" "$@"\n');
+  await writeFile(
+    envInspector,
+    `process.argv = ['node'];
+process.exit = code => { throw new Error(\`exit \${code}\`); };
+try { await import(${JSON.stringify(new URL('./index.js', import.meta.url).href)}); } catch {}
+console.log(\`inspected_node_options=\${process.env.NODE_OPTIONS || ''}\`);
+`
+  );
+  await writeFile(
+    fakeCommand,
+    `#!/bin/bash
+[ "$1" = "--terminate" ] && kill -TERM $$
+[ "$1" = "--inspect-entry" ] && exec node "${envInspector}"
+/usr/bin/env
+printf "arg=%s\\n" "$@"
+`
+  );
   await chmod(fakeCommand, 0o755);
   if (nodeMajorVersion === null) {
     await symlink(process.execPath, join(directory, 'node'));
@@ -40,10 +57,13 @@ async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv
 }
 
 describe('codecritique.sh', () => {
-  it('rejects Node versions below the supported minimum', async () => {
-    await expect(runWrapper(null, [], 'codecritique', {}, false, 20)).rejects.toMatchObject({
+  it.each([
+    [20, 'Error: CodeCritique requires Node.js 24 or newer (found v20.0.0).\n'],
+    ['not-a-version', 'Error: Unable to determine the Node.js major version (received: not-a-version).\n'],
+  ])('rejects unsupported Node version output: %s', async (nodeVersion, stderr) => {
+    await expect(runWrapper(null, [], 'codecritique', {}, false, nodeVersion)).rejects.toMatchObject({
       code: 1,
-      stderr: 'Error: CodeCritique requires Node.js 24 or newer (found v20.0.0).\n',
+      stderr,
     });
   });
 
@@ -66,6 +86,12 @@ describe('codecritique.sh', () => {
     expect(stdout).toContain('ANTHROPIC_API_KEY=test');
     expect(stdout).not.toContain('NODE_OPTIONS=');
     await expect(access(join(directory, 'executed'))).rejects.toThrow();
+  });
+
+  it('prevents the real CLI entry point from reloading filtered .env values', async () => {
+    const { stdout } = await runWrapper('ANTHROPIC_API_KEY=test\nNODE_OPTIONS=--require=./does-not-exist.cjs\n', ['--inspect-entry']);
+
+    expect(stdout).toContain('inspected_node_options=\n');
   });
 
   it('forwards every supported .env setting', async () => {
@@ -110,14 +136,8 @@ describe('codecritique.sh', () => {
     expect(stdout).toContain('ANTHROPIC_API_KEY=from-file');
   });
 
-  it('warns when no Anthropic credentials are configured', async () => {
-    const { stderr } = await runWrapper(null);
-
-    expect(stderr).toContain('Warning: ANTHROPIC_API_KEY is not set.');
-  });
-
-  it('does not treat an unsupported Anthropic auth token as configured', async () => {
-    const { stderr } = await runWrapper('ANTHROPIC_AUTH_TOKEN=token\n');
+  it.each([null, 'ANTHROPIC_AUTH_TOKEN=token\n'])('warns when no supported Anthropic credentials are configured', async (envFile) => {
+    const { stderr } = await runWrapper(envFile);
 
     expect(stderr).toContain('Warning: ANTHROPIC_API_KEY is not set.');
   });

--- a/src/codecritique.test.js
+++ b/src/codecritique.test.js
@@ -32,6 +32,7 @@ console.log(\`inspected_node_options=\${process.env.NODE_OPTIONS || ''}\`);
     `#!/bin/bash
 [ "$1" = "--terminate" ] && kill -TERM $$
 [ "$1" = "--inspect-entry" ] && exec node "${envInspector}"
+[ "$1" = "--inspect-entry-with-dotenv" ] && unset CODECRITIQUE_SKIP_DOTENV && exec node "${envInspector}"
 /usr/bin/env
 printf "arg=%s\\n" "$@"
 `
@@ -92,6 +93,12 @@ describe('codecritique.sh', () => {
     const { stdout } = await runWrapper('ANTHROPIC_API_KEY=test\nNODE_OPTIONS=--require=./does-not-exist.cjs\n', ['--inspect-entry']);
 
     expect(stdout).toContain('inspected_node_options=\n');
+  });
+
+  it('loads .env at the real CLI entry point when the wrapper sentinel is absent', async () => {
+    const { stdout } = await runWrapper('ANTHROPIC_API_KEY=test\nNODE_OPTIONS=loaded-by-dotenv\n', ['--inspect-entry-with-dotenv']);
+
+    expect(stdout).toContain('inspected_node_options=loaded-by-dotenv\n');
   });
 
   it('forwards every supported .env setting', async () => {

--- a/src/codecritique.test.js
+++ b/src/codecritique.test.js
@@ -7,7 +7,7 @@ import { describe, expect, it, onTestFinished } from 'vitest';
 
 const execFileAsync = promisify(execFile);
 
-async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv = {}, envIsDirectory = false) {
+async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv = {}, envIsDirectory = false, nodeMajorVersion = null) {
   const directory = await mkdtemp(join(tmpdir(), 'codecritique-shell-'));
   onTestFinished(() => rm(directory, { recursive: true, force: true }));
   const fakeCommand = join(directory, command);
@@ -18,12 +18,18 @@ async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv
   else if (envFile !== null) {
     await writeFile(join(directory, '.env'), envFile);
   }
-  await writeFile(
-    fakeCommand,
-    '#!/bin/bash\n[ "$1" = "--terminate" ] && kill -TERM $$\nprintf "key=%s\\n" "$ANTHROPIC_API_KEY"\nprintf "node_options=%s\\n" "$NODE_OPTIONS"\nprintf "arg=%s\\n" "$@"\n'
-  );
+  await writeFile(fakeCommand, '#!/bin/bash\n[ "$1" = "--terminate" ] && kill -TERM $$\n/usr/bin/env\nprintf "arg=%s\\n" "$@"\n');
   await chmod(fakeCommand, 0o755);
-  await symlink(process.execPath, join(directory, 'node'));
+  if (nodeMajorVersion === null) {
+    await symlink(process.execPath, join(directory, 'node'));
+  }
+  else {
+    await writeFile(
+      join(directory, 'node'),
+      `#!/bin/bash\nif [ "$1" = "-p" ]; then echo ${nodeMajorVersion}; exit; fi\nif [ "$1" = "--version" ]; then echo v${nodeMajorVersion}.0.0; exit; fi\nexec "${process.execPath}" "$@"\n`
+    );
+    await chmod(join(directory, 'node'), 0o755);
+  }
 
   const result = await execFileAsync('/bin/bash', [join(import.meta.dirname, 'codecritique.sh'), ...args], {
     cwd: directory,
@@ -34,13 +40,20 @@ async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv
 }
 
 describe('codecritique.sh', () => {
+  it('rejects Node versions below the supported minimum', async () => {
+    await expect(runWrapper(null, [], 'codecritique', {}, false, 20)).rejects.toMatchObject({
+      code: 1,
+      stderr: 'Error: CodeCritique requires Node.js 24 or newer (found v20.0.0).\n',
+    });
+  });
+
   it.each([
     ['unquoted spaces and globs', 'ANTHROPIC_API_KEY=value with spaces *\n', 'value with spaces *'],
     ['literal JSON quotes', 'ANTHROPIC_API_KEY={"token":"a*b c"}\n', '{"token":"a*b c"}'],
   ])('loads %s without corruption', async (_label, envFile, expected) => {
     const { stdout } = await runWrapper(envFile, ['--flag', 'value with spaces']);
 
-    expect(stdout).toContain(`key=${expected}`);
+    expect(stdout).toContain(`ANTHROPIC_API_KEY=${expected}`);
     expect(stdout).toContain('arg=--flag');
     expect(stdout).toContain('arg=value with spaces');
   });
@@ -50,15 +63,43 @@ describe('codecritique.sh', () => {
       'ANTHROPIC_API_KEY=test\nMALICIOUS=$(touch executed)\nNODE_OPTIONS=--require=./does-not-exist.cjs\n'
     );
 
-    expect(stdout).toContain('key=test');
-    expect(stdout).toContain('node_options=\n');
+    expect(stdout).toContain('ANTHROPIC_API_KEY=test');
+    expect(stdout).not.toContain('NODE_OPTIONS=');
     await expect(access(join(directory, 'executed'))).rejects.toThrow();
+  });
+
+  it('forwards every supported .env setting', async () => {
+    const supportedEnv = {
+      ANTHROPIC_API_KEY: 'test',
+      ANTHROPIC_BASE_URL: 'https://api.example.test',
+      ANTHROPIC_LOG: 'debug',
+      GITHUB_TOKEN: 'github-token',
+      GH_TOKEN: 'gh-token',
+      DEBUG: '1',
+      VERBOSE: 'true',
+      CI: 'true',
+      GITHUB_WORKSPACE_PATH: '/workspace',
+    };
+    const envFile = Object.entries(supportedEnv)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n');
+    const { stdout } = await runWrapper(envFile);
+
+    for (const [key, value] of Object.entries(supportedEnv)) {
+      expect(stdout).toContain(`${key}=${value}`);
+    }
+  });
+
+  it('reports null bytes in supported values without an internal stack', async () => {
+    await expect(runWrapper('ANTHROPIC_API_KEY=test\0value\n')).rejects.toMatchObject({
+      stderr: 'Unable to load .env: ANTHROPIC_API_KEY contains a null byte\n',
+    });
   });
 
   it('preserves an inherited API key when .env is absent', async () => {
     const { stdout } = await runWrapper(null, [], 'codecritique', { ANTHROPIC_API_KEY: 'inherited' });
 
-    expect(stdout).toContain('key=inherited');
+    expect(stdout).toContain('ANTHROPIC_API_KEY=inherited');
   });
 
   it('keeps the original .env-over-inherited-value precedence', async () => {
@@ -66,7 +107,7 @@ describe('codecritique.sh', () => {
       ANTHROPIC_API_KEY: 'from-parent',
     });
 
-    expect(stdout).toContain('key=from-file');
+    expect(stdout).toContain('ANTHROPIC_API_KEY=from-file');
   });
 
   it('warns when no Anthropic credentials are configured', async () => {

--- a/src/codecritique.test.js
+++ b/src/codecritique.test.js
@@ -1,0 +1,101 @@
+import { execFile } from 'node:child_process';
+import { access, chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it, onTestFinished } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+async function runWrapper(envFile, args = [], command = 'codecritique', extraEnv = {}, envIsDirectory = false) {
+  const directory = await mkdtemp(join(tmpdir(), 'codecritique-shell-'));
+  onTestFinished(() => rm(directory, { recursive: true, force: true }));
+  const fakeCommand = join(directory, command);
+
+  if (envIsDirectory) {
+    await mkdir(join(directory, '.env'));
+  }
+  else if (envFile !== null) {
+    await writeFile(join(directory, '.env'), envFile);
+  }
+  await writeFile(
+    fakeCommand,
+    '#!/bin/bash\n[ "$1" = "--terminate" ] && kill -TERM $$\nprintf "key=%s\\n" "$ANTHROPIC_API_KEY"\nprintf "node_options=%s\\n" "$NODE_OPTIONS"\nprintf "arg=%s\\n" "$@"\n'
+  );
+  await chmod(fakeCommand, 0o755);
+  await symlink(process.execPath, join(directory, 'node'));
+
+  const result = await execFileAsync('/bin/bash', [join(import.meta.dirname, 'codecritique.sh'), ...args], {
+    cwd: directory,
+    env: { PATH: directory, ...extraEnv },
+  });
+
+  return { ...result, directory };
+}
+
+describe('codecritique.sh', () => {
+  it.each([
+    ['unquoted spaces and globs', 'ANTHROPIC_API_KEY=value with spaces *\n', 'value with spaces *'],
+    ['literal JSON quotes', 'ANTHROPIC_API_KEY={"token":"a*b c"}\n', '{"token":"a*b c"}'],
+  ])('loads %s without corruption', async (_label, envFile, expected) => {
+    const { stdout } = await runWrapper(envFile, ['--flag', 'value with spaces']);
+
+    expect(stdout).toContain(`key=${expected}`);
+    expect(stdout).toContain('arg=--flag');
+    expect(stdout).toContain('arg=value with spaces');
+  });
+
+  it('does not execute .env contents', async () => {
+    const { directory, stdout } = await runWrapper(
+      'ANTHROPIC_API_KEY=test\nMALICIOUS=$(touch executed)\nNODE_OPTIONS=--require=./does-not-exist.cjs\n'
+    );
+
+    expect(stdout).toContain('key=test');
+    expect(stdout).toContain('node_options=\n');
+    await expect(access(join(directory, 'executed'))).rejects.toThrow();
+  });
+
+  it('preserves an inherited API key when .env is absent', async () => {
+    const { stdout } = await runWrapper(null, [], 'codecritique', { ANTHROPIC_API_KEY: 'inherited' });
+
+    expect(stdout).toContain('key=inherited');
+  });
+
+  it('keeps the original .env-over-inherited-value precedence', async () => {
+    const { stdout } = await runWrapper('ANTHROPIC_API_KEY=from-file\n', [], 'codecritique', {
+      ANTHROPIC_API_KEY: 'from-parent',
+    });
+
+    expect(stdout).toContain('key=from-file');
+  });
+
+  it('warns when no Anthropic credentials are configured', async () => {
+    const { stderr } = await runWrapper(null);
+
+    expect(stderr).toContain('Warning: ANTHROPIC_API_KEY is not set.');
+  });
+
+  it('does not treat an unsupported Anthropic auth token as configured', async () => {
+    const { stderr } = await runWrapper('ANTHROPIC_AUTH_TOKEN=token\n');
+
+    expect(stderr).toContain('Warning: ANTHROPIC_API_KEY is not set.');
+  });
+
+  it('reports unreadable .env paths without an internal stack', async () => {
+    await expect(runWrapper(null, [], 'codecritique', {}, true)).rejects.toMatchObject({
+      stderr: expect.stringMatching(/^Unable to load \.env: .+\n$/),
+    });
+  });
+
+  it('falls back to npx when codecritique is not installed globally', async () => {
+    const { stdout } = await runWrapper('ANTHROPIC_API_KEY=test\n', ['--version'], 'npx');
+
+    expect(stdout).toContain('codecritique not found globally, trying with npx...');
+    expect(stdout).toContain('arg=codecritique');
+    expect(stdout).toContain('arg=--version');
+  });
+
+  it('preserves signal-derived child exit codes', async () => {
+    await expect(runWrapper('ANTHROPIC_API_KEY=test\n', ['--terminate'])).rejects.toMatchObject({ code: 143 });
+  });
+});

--- a/src/embeddings/model-manager.js
+++ b/src/embeddings/model-manager.js
@@ -20,15 +20,11 @@
 
 import fs from 'node:fs';
 import chalk from 'chalk';
-import dotenv from 'dotenv';
 import { EmbeddingModel, FlagEmbedding } from 'fastembed';
 import { debug, verboseLog } from '../utils/logging.js';
 import { EMBEDDING_DIMENSIONS, MODEL_NAME_STRING, MAX_RETRIES } from './constants.js';
 import { FASTEMBED_CACHE_DIR } from './constants.js';
 import { createModelInitializationError, createEmbeddingGenerationError } from './errors.js';
-
-// Load environment variables
-dotenv.config({ quiet: true });
 
 // ============================================================================
 // MODEL MANAGER CLASS

--- a/src/llm.js
+++ b/src/llm.js
@@ -18,7 +18,9 @@ import dotenv from 'dotenv';
 import { verboseLog } from './utils/logging.js';
 
 // Load env variables if present; do not enforce key at import time
-dotenv.config({ quiet: true });
+if (process.env.CODECRITIQUE_SKIP_DOTENV !== '1') {
+  dotenv.config({ quiet: true });
+}
 
 let anthropic = null;
 


### PR DESCRIPTION
This PR replaces shell-based `.env` expansion with Node `util.parseEnv` so values containing spaces, quotes, and glob characters are preserved without evaluating project files as code.

- Requires Node.js 24 or newer and rejects invalid version-probe output before parsing `.env`.
- Forwards only the documented CodeCritique, Anthropic, GitHub, and CI settings; process-control variables such as `NODE_OPTIONS` and `PATH` are ignored.
- Prevents the child CLI from reloading filtered `.env` values during module initialization.
- Documents `CODECRITIQUE_SKIP_DOTENV=1` for callers that intentionally disable `.env` loading.
- Preserves `.env` precedence, global-command/npx fallback, arguments, and child exit behavior.
- Rejects NUL-bearing supported values before child execution.

## Behavior notes

- An unreadable `.env` aborts with a concise stderr error instead of being skipped.
- Missing-key warnings are written to stderr.
- Run the wrapper only in trusted project directories: `ANTHROPIC_BASE_URL` can redirect API traffic, while `CI` and `GITHUB_WORKSPACE_PATH` control embedding storage.

## Test plan

- `npm test` (1,336 tests)
- `npm run test:coverage`
- `npm run lint`
- `npm run prettier:ci`
- `bash -n src/codecritique.sh`
- focused wrapper tests (16 tests)

Both required pre-push review passes approved the final follow-up with no actionable findings.