### PR TITLE
Update model routing and token estimates

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: 'false'
 
   model:
-    description: 'LLM model to use (e.g., claude-sonnet-4-5)'
+    description: 'LLM model to use (e.g., claude-sonnet-4-6)'
     required: false
 
   max-tokens:

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ jobs:
 | `anthropic-api-key` | Anthropic API key for Claude models                                                                      | **Yes**  | -                    |
 | `skip-label`        | Label name to skip AI review                                                                             | No       | `ai-review-disabled` |
 | `verbose`           | Show verbose output                                                                                      | No       | `false`              |
-| `model`             | LLM model to use (e.g., `claude-sonnet-4-5`)                                                             | No       | Auto-selected        |
+| `model`             | LLM model to use (e.g., `claude-sonnet-4-6`)                                                             | No       | Auto-selected        |
 | `max-tokens`        | Maximum tokens for LLM response                                                                          | No       | Auto-calculated      |
 | `cache-ttl`         | Cache TTL for LLM prompts: "5m" (default, no extra cost) or "1h" (extended, extra cost for cache writes) | No       | `5m`                 |
 | `concurrency`       | Concurrency for processing multiple files                                                                | No       | `3`                  |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ Retrieval is also defensive about freshness and project isolation. Results are f
 
 ### LLM Integration
 
-[Anthropic Claude](https://www.anthropic.com/) (claude-sonnet-4-5 by default) analyzes code with rich contextual information. The retrieved context is combined with the code being reviewed and sent to Claude, which performs a comprehensive analysis considering:
+[Anthropic Claude](https://www.anthropic.com/) (claude-sonnet-4-6 by default) analyzes code with rich contextual information. The retrieved context is combined with the code being reviewed and sent to Claude, which performs a comprehensive analysis considering:
 
 - The code structure and logic
 - Similar patterns from your codebase

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -21,7 +21,7 @@ codecritique analyze [options]
 | `--output-file <file>`            | Save output to file (useful with --output json)                                                                                               | -             |
 | `--no-color`                      | Disable colored output                                                                                                                        | `false`       |
 | `--verbose`                       | Show verbose output                                                                                                                           | `false`       |
-| `--model <model>`                 | LLM model to use (e.g., claude-sonnet-4-5)                                                                                                    | Auto-selected |
+| `--model <model>`                 | LLM model to use (e.g., claude-sonnet-4-6)                                                                                                    | Auto-selected |
 | `--temperature <number>`          | LLM temperature                                                                                                                               | `0.2`         |
 | `--max-tokens <number>`           | LLM max tokens                                                                                                                                | `8192`        |
 | `--cache-ttl <ttl>`               | Cache TTL for LLM prompts: "5m" (default, no extra cost) or "1h" (extended, extra cost for cache writes)                                      | `5m`          |

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ program
   .option('--output-file <file>', 'Save output to file (useful with --output json)')
   .option('--no-color', 'Disable colored output')
   .option('--verbose', 'Show verbose output')
-  .option('--model <model>', 'LLM model to use (e.g., claude-sonnet-4-5)')
+  .option('--model <model>', 'LLM model to use (e.g., claude-sonnet-4-6)')
   .option('--temperature <number>', 'LLM temperature', parseFloat, 0.2)
   .option('--max-tokens <number>', 'LLM max tokens', parseInt, 8192)
   .option('--cache-ttl <ttl>', 'Cache TTL for LLM prompts: "5m" (default, no extra cost) or "1h" (extended, extra cost for writes)', '5m')

--- a/src/llm.js
+++ b/src/llm.js
@@ -39,7 +39,7 @@ function getAnthropicClient() {
 }
 
 // Default model
-const DEFAULT_MODEL = 'claude-sonnet-4-5';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 
 // Maximum tokens for response
 const MAX_TOKENS = 4096;

--- a/src/llm.test.js
+++ b/src/llm.test.js
@@ -49,7 +49,7 @@ describe('sendPromptToClaude', () => {
 
       expect(mockMessagesCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'claude-sonnet-4-5',
+          model: 'claude-sonnet-4-6',
           max_tokens: 4096,
           temperature: 0.7,
         })

--- a/src/project-analyzer.js
+++ b/src/project-analyzer.js
@@ -17,6 +17,7 @@ import { verboseLog } from './utils/logging.js';
 import { escapeSqlString } from './utils/string-utils.js';
 
 const TERM_SEARCH_CONTENT_CANDIDATE_LIMIT = 500;
+const PROJECT_ANALYSIS_MODEL = 'claude-haiku-4-5';
 
 // Consolidated file classification configuration
 const FILE_PATTERNS = {
@@ -586,6 +587,7 @@ Select files following the criteria in the system instructions.`;
       };
 
       const response = await this.llm.sendPromptToClaude(prompt, {
+        model: PROJECT_ANALYSIS_MODEL,
         system: FILE_SELECTION_SYSTEM_PROMPT,
         temperature: 0.1,
         maxTokens: 1000,
@@ -878,6 +880,7 @@ Follow the analysis guidelines from the system instructions to identify custom i
       };
 
       const response = await this.llm.sendPromptToClaude(prompt, {
+        model: PROJECT_ANALYSIS_MODEL,
         system: PROJECT_SUMMARY_SYSTEM_PROMPT,
         temperature: 0.1,
         maxTokens: 4000,
@@ -886,7 +889,7 @@ Follow the analysis guidelines from the system instructions to identify custom i
 
       const summary = response.json;
       if (summary) {
-        // Validate and ensure required fields exist (Sonnet 4.5 compatibility)
+        // Validate and ensure required fields exist across model responses
         const validatedSummary = this.validateProjectSummary(summary);
 
         // Add metadata

--- a/src/project-analyzer.test.js
+++ b/src/project-analyzer.test.js
@@ -556,7 +556,7 @@ describe('ProjectAnalyzer', () => {
 
       const result = await analyzer.selectFinalKeyFiles(candidates, mockProjectPath);
 
-      expect(llm.sendPromptToClaude).toHaveBeenCalled();
+      expect(llm.sendPromptToClaude).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ model: 'claude-haiku-4-5' }));
       expect(result.length).toBe(1);
       expect(result[0].relativePath).toBe('package.json');
     });
@@ -668,9 +668,11 @@ describe('ProjectAnalyzer', () => {
         content: JSON.stringify(mockSummary),
         json: mockSummary,
       });
+      analyzer.llm = llm;
 
       const result = await analyzer.generateProjectSummary(mockKeyFiles, mockProjectPath);
 
+      expect(llm.sendPromptToClaude).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ model: 'claude-haiku-4-5' }));
       expect(result.projectName).toBe('test-project');
       expect(result.analysisDate).toBeDefined();
       expect(result.projectPath).toBe(mockProjectPath);

--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -764,7 +764,7 @@ function prepareContextForLLM(filePath, content, language, finalCodeExamples, fi
 async function callLLMForAnalysis(context, options = {}) {
   try {
     let prompt;
-    const model = options.model || 'claude-sonnet-4-5';
+    const model = options.model || 'claude-sonnet-4-6';
     const maxTokens = options.maxTokens || 8192; // Default to a safe limit
 
     if (options.isHolisticPRReview) {

--- a/src/utils/pr-chunking.test.js
+++ b/src/utils/pr-chunking.test.js
@@ -28,7 +28,7 @@ describe('shouldChunkPR', () => {
     it('should chunk PR when total tokens exceed threshold', () => {
       // Create files that will exceed the 100k token threshold
       // Each file needs: diff content + full content + 25k context overhead
-      const largeContent = 'x'.repeat(90000); // 30k tokens per file
+      const largeContent = 'x'.repeat(90000); // About 25.7k estimated tokens
       const prFiles = Array.from({ length: 5 }, (_, i) => ({
         filePath: `src/file${i}.js`,
         diffContent: largeContent,

--- a/src/utils/pr-chunking.test.js
+++ b/src/utils/pr-chunking.test.js
@@ -19,8 +19,8 @@ describe('shouldChunkPR', () => {
       const prFiles = [{ filePath: 'src/utils.js', diffContent: 'a'.repeat(300), content: 'b'.repeat(600) }];
       const result = shouldChunkPR(prFiles);
       expect(result.estimatedTokens).toBeGreaterThan(0);
-      expect(result.diffTokens).toBe(100); // 300 chars / 3
-      expect(result.fullContentTokens).toBe(200); // 600 chars / 3
+      expect(result.diffTokens).toBe(86); // 300 chars / 3.5
+      expect(result.fullContentTokens).toBe(172); // 600 chars / 3.5
     });
   });
 
@@ -268,7 +268,7 @@ describe('chunkPRFiles', () => {
         'diff --git a/src/huge.js b/src/huge.js',
         '--- a/src/huge.js',
         '+++ b/src/huge.js',
-        `@@ -150,1 +150,1 @@\n-old\n+${'x'.repeat(120000)}`,
+        `@@ -150,1 +150,1 @@\n-old\n+${'x'.repeat(140000)}`,
       ].join('\n');
 
       const chunks = chunkPRFiles([{ filePath: 'src/huge.js', diffContent: hugeDiff, content: 'y'.repeat(1200) }], 35000, {

--- a/src/utils/pr-file-context.js
+++ b/src/utils/pr-file-context.js
@@ -1,7 +1,7 @@
 import { parseDiffLineInfo } from './diff-lines.js';
 import { addLineNumbers } from './string-utils.js';
 
-// Conservative midpoint for source code; the prompt-size safety buffer covers tokenizer variance.
+// Calibrated source-code estimate; the prompt-size safety buffer covers tokenizer variance.
 export const CHARS_PER_ESTIMATED_TOKEN = 3.5;
 const DEFAULT_CONTEXT_LINE_RADIUS = 40;
 const DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE = 12000;

--- a/src/utils/pr-file-context.js
+++ b/src/utils/pr-file-context.js
@@ -1,7 +1,8 @@
 import { parseDiffLineInfo } from './diff-lines.js';
 import { addLineNumbers } from './string-utils.js';
 
-export const CHARS_PER_ESTIMATED_TOKEN = 3;
+// Conservative midpoint for source code; the prompt-size safety buffer covers tokenizer variance.
+export const CHARS_PER_ESTIMATED_TOKEN = 3.5;
 const DEFAULT_CONTEXT_LINE_RADIUS = 40;
 const DEFAULT_MAX_FULL_CONTENT_TOKENS_PER_FILE = 12000;
 export const DEFAULT_MAX_TOTAL_FULL_CONTENT_TOKENS = 60000;

--- a/src/utils/pr-file-context.test.js
+++ b/src/utils/pr-file-context.test.js
@@ -5,6 +5,10 @@ import {
   mergeHolisticFileContextPlans,
 } from './pr-file-context.js';
 
+it('estimates source code at 3.5 characters per token', () => {
+  expect(estimatePrContextTokens('x'.repeat(35))).toBe(10);
+});
+
 describe('mergeHolisticFileContextPlans', () => {
   it('keeps complete file content when the PR fits the holistic context budget', () => {
     const plans = mergeHolisticFileContextPlans([


### PR DESCRIPTION
This PR updates the model and token-cost defaults from the original audit without adding a routing framework.

- Uses Claude Sonnet 4.6 for code reviews.
- Uses Claude Haiku 4.5 for key-file selection and project summaries.
- Calibrates source-code estimates from 3 to 3.5 characters per token while retaining the existing prompt safety buffer.
- Updates CLI, action, and documentation examples.

Sonnet 4.6 is intentionally pinned for compatibility: moving to Sonnet 5 also requires removing non-default temperature parameters and recalibrating token estimates for its tokenizer, so that migration belongs in a separate PR.

## Test plan

- `npx vitest run src/llm.test.js src/project-analyzer.test.js src/utils/pr-file-context.test.js src/utils/pr-chunking.test.js` (115 tests)
- `npm test` (1,321 tests)
- `npm run lint`
- `npm run prettier:ci`

Both requested pre-push reviews approved the final feedback changes with no actionable findings.