### PR TITLE
Deduplicate retrieved code context by content

### DIFF
--- a/src/rag-analyzer.js
+++ b/src/rag-analyzer.js
@@ -2343,7 +2343,8 @@ async function gatherUnifiedContextForPR(prFiles, options = {}) {
   // Aggregate and deduplicate results
   for (const context of allContexts) {
     (context.finalCodeExamples || []).forEach((example) => {
-      const key = example.path;
+      const normalizedContent = example.content?.trim();
+      const key = normalizedContent ? `content:${normalizedContent}` : example.path ? `path:${example.path}` : null;
       if (
         key &&
         (!allProcessedContext.codeExamples.has(key) || example.similarity > allProcessedContext.codeExamples.get(key).similarity)

--- a/src/rag-analyzer.test.js
+++ b/src/rag-analyzer.test.js
@@ -1136,6 +1136,32 @@ describe('rag-analyzer', () => {
         expect(context.codeExamples[0].similarity).toBeGreaterThanOrEqual(0.7);
       }
     });
+
+    it('should deduplicate identical code content from different paths', async () => {
+      mockEmbeddingsSystem.findSimilarCode
+        .mockResolvedValueOnce([{ path: '/first.js', content: 'shared implementation', similarity: 0.7 }])
+        .mockResolvedValueOnce([{ path: '/second.js', content: ' shared implementation ', similarity: 0.9 }]);
+      const context = await gatherUnifiedContextForPR([
+        { filePath: '/src/file1.js', content: 'code1' },
+        { filePath: '/src/file2.js', content: 'code2' },
+      ]);
+
+      expect(context.codeExamples).toEqual([
+        expect.objectContaining({ path: '/second.js', content: ' shared implementation ', similarity: 0.9 }),
+      ]);
+    });
+
+    it('should keep content keys separate from path fallbacks', async () => {
+      mockEmbeddingsSystem.findSimilarCode
+        .mockResolvedValueOnce([{ path: '/first.js', content: '', similarity: 0.9 }])
+        .mockResolvedValueOnce([{ path: '/second.js', content: ' /first.js ', similarity: 0.8 }]);
+      const context = await gatherUnifiedContextForPR([
+        { filePath: '/src/file1.js', content: 'code1' },
+        { filePath: '/src/file2.js', content: 'code2' },
+      ]);
+
+      expect(context.codeExamples.map((example) => example.path)).toEqual(['/first.js', '/second.js']);
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
This PR trims repeated code context from holistic reviews by deduplicating normalized example content at PR-level aggregation.

- Keeps the highest-similarity representative when different paths contain identical code.
- Falls back to path identity for examples without content.
- Separates content and path key namespaces to avoid false collisions.

Tradeoff: identical content found at multiple paths is represented once, deliberately favoring distinct examples over preserving the number of locations where a pattern appears.

## Test plan

- `npx vitest run src/rag-analyzer.test.js` (95 tests)
- `npm test` (1,322 tests)
- `npm run lint`
- `npm run prettier:ci`

Both requested pre-push reviews completed with no actionable findings.