### PR TITLE
chore(deps-dev): bump prettier from 3.8.3 to 3.9.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint-plugin-import": "2.32.0",
         "globals": "16.5.0",
         "knip": "5.70.2",
-        "prettier": "3.8.3",
+        "prettier": "3.9.6",
         "prettier-plugin-brace-style": "0.10.3",
         "typescript": "5.9.3",
         "vitest": "4.1.10"
@@ -10364,9 +10364,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-import": "2.32.0",
     "globals": "16.5.0",
     "knip": "5.70.2",
-    "prettier": "3.8.3",
+    "prettier": "3.9.6",
     "prettier-plugin-brace-style": "0.10.3",
     "typescript": "5.9.3",
     "vitest": "4.1.10"

--- a/src/utils/pr-chunking.js
+++ b/src/utils/pr-chunking.js
@@ -286,7 +286,7 @@ function splitLargeDiffUnit(headerText, unit, maxChars, hasPreviousPart) {
   const parts = [];
   const hunkHeader = unit.split('\n').find((line) => line.startsWith('@@'));
 
-  for (let offset = 0; offset < unit.length; ) {
+  for (let offset = 0; offset < unit.length;) {
     const isContinuation = hasPreviousPart || parts.length > 0;
     const continuationHunkHeader = offset > 0 ? adjustHunkHeaderNewStart(hunkHeader, estimateNewLineAtOffset(unit, offset)) : '';
     const prefix = buildBoundedDiffPrefix(headerText, isContinuation, maxChars, continuationHunkHeader);


### PR DESCRIPTION
Replaces #102, which cannot pass CI on its own.

## Why #102 fails

`Code linting (npm run prettier:ci)` is red on #102. Prettier 3.9 changed one formatting rule, so a file that was correctly formatted under 3.8.3 is no longer correctly formatted under 3.9.6. Dependabot only bumps the dependency, so the check fails.

The affected file is `src/utils/pr-chunking.js`, and the change is a single space:

```diff
-  for (let offset = 0; offset < unit.length; ) {
+  for (let offset = 0; offset < unit.length;) {
```

Prettier 3.9 no longer prints a space before the closing paren of a `for` loop with an empty update clause.

This is prettier core, not `prettier-plugin-brace-style`. Verified by running 3.9.6 against a config with no plugins — it produces the same output. Both `prettier-plugin-brace-style` 0.10.1 and 0.10.3 declare `prettier: "^3"`, so 3.9.6 is inside the supported range either way.

## Change

- `prettier` 3.8.3 to 3.9.6
- reformat the one affected line

`prettier --write .` across the whole repo touched only that file. The source diff is whitespace only — `git diff -w` on it is empty. The lockfile diff is 4 lines: version, resolved, integrity, and the devDependency spec.

## Verification

Run against a clean `npm ci` on this branch:

- `npm run prettier:ci`: exit 0, all files pass (cache deleted first, so this is a real check and not a cache hit)
- `npm run lint:ci`: exit 0
- `npm test`: 42 files, 1353 tests passed
- Control: on `main` with 3.8.3, `prettier --check .` also passes — so the one file is the entire difference between the two versions

## Unrelated issue found

`npm run test:types` is broken on `main`, before and after this change. The script runs `tsc --noEmit`, but there is no `tsconfig.json` in the repo, so `tsc` prints its usage text and exits 1. CI does not run this script, so nothing is red because of it. Worth a separate fix.